### PR TITLE
add cache lookup to skip things already processed

### DIFF
--- a/config/cdConfig.js
+++ b/config/cdConfig.js
@@ -24,7 +24,13 @@ module.exports =
     crawler: {
       count: 1
     },
+    filter: {
+      provider: 'filter',
+      filter: {}
+    },
     fetch: {
+      dispatcher: 'cdDispatch',
+      cdDispatch: {},
       git: {},
       npm: {}
     },

--- a/lib/baseHandler.js
+++ b/lib/baseHandler.js
@@ -25,6 +25,22 @@ class BaseHandler {
     };
   }
 
+  canHandle(request) {
+    return false;
+  }
+
+  shouldProcess(request) {
+    return request.policy.shouldProcess(request, this.schemaVersion);
+  }
+
+  shouldTraverse(request) {
+    return request.policy.shouldTraverse(request);
+  }
+
+  isProcessing(request) {
+    return request.processMode === 'process';
+  }
+
   _process(request) {
     request.document._metadata.version = this.schemaVersion || 1;
     return { document: request.document, spec: this.toSpec(request) };
@@ -72,11 +88,12 @@ class BaseHandler {
   }
 
   addBasicToolLinks(request, spec) {
-    request.linkResource('self', this._getToolUrn(spec));
+    request.linkResource('self', this.getUrnFor(request, spec));
     request.linkSiblings(spec.toUrn());
   }
 
-  _getToolUrn(spec) {
+  getUrnFor(request, spec = null) {
+    spec = spec || this.toSpec(request);
     const newSpec = Object.assign(Object.create(spec), spec, this.toolSpec);
     return newSpec.toUrn();
   }

--- a/lib/sourceSpec.js
+++ b/lib/sourceSpec.js
@@ -5,6 +5,12 @@ const EntitySpec = require('./entitySpec');
 
 class SourceSpec {
 
+  static adopt(object) {
+    if (object && object.__proto__ !== SourceSpec.prototype)
+      object.__proto__ = SourceSpec.prototype;
+    return object;
+  }
+
   constructor(type, provider, url, revision = null, path = null) {
     this.type = type;
     this.provider = provider;

--- a/providers/fetch/dispatcher.js
+++ b/providers/fetch/dispatcher.js
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+const BaseHandler = require('../../lib/baseHandler');
+
+class FetchDispatcher extends BaseHandler {
+
+  constructor(options, store, fetchers, processors, filter) {
+    super(options);
+    this.store = store;
+    this.fetchers = fetchers;
+    this.processors = processors;
+    this.filter = filter;
+  }
+
+  canHandle(request, type = request.type) {
+    // handle all fetch requests
+    return true;
+  }
+
+  async handle(request) {
+    const start = Date.now();
+    try {
+      const documentKey = this._getDocumentKey(request);
+      const document = await this.store.get(request.type, documentKey);
+      if (!document)
+        return this._fetchMissing(request);
+      request.addMeta({ read: Date.now() - start });
+      request.response = { headers: {} };
+      request.document = document;
+      request.contentOrigin = 'storage';
+      return this._dispatchFetch(request);
+    } catch (erorr) {
+      // TODO eating the error here. at least log
+      return this._fetchMissing(request);
+    }
+  }
+
+  _getDocumentKey(request) {
+    const processors = this._getHandlers(request, this.processors);
+    if (processors.length !== 1)
+      throw new Error(`Wrong number of processors for ${request.toString()}: ${processors.length}`);
+    return processors[0].getUrnFor(request);
+  }
+
+  async _fetchMissing(request) {
+    // The doc could not be loaded from storage. Either storage has failed somehow or this
+    // is a new processing path. Decide if we should use the origin store, or skip.
+    if (this.filter.shouldFetchMissing(request))
+      return this._dispatchFetch(request);
+    return request.markSkip('Unreachable for reprocessing');
+  }
+
+  async _dispatchFetch(request, force = false) {
+    if (!force && this.filter && !this.filter.shouldFetch(request))
+      return request;
+    // get the right real fetcher(s) for this request and dispatch
+    const handlers = this._getHandlers(request, this.fetchers);
+    return Promise.all(handlers.map(fetcher => fetcher.handle(request)))
+      .then(results => request);
+  }
+
+  // get all the handlers that apply to this request
+  _getHandlers(request, list) {
+    return list.filter(element => element.canHandle(request));
+  }
+}
+
+module.exports = (options, store, fetchers, processors, filter) => new FetchDispatcher(options, store, fetchers, processors, filter);

--- a/providers/fetch/gitCloner.js
+++ b/providers/fetch/gitCloner.js
@@ -7,20 +7,17 @@ const SourceSpec = require('../../lib/sourceSpec');
 
 class GitHubCloner extends BaseHandler {
 
-  get schemaVersion() {
-    return 1;
-  }
-
-  getHandler(request, type = request.type) {
+  canHandle(request, type = request.type) {
     const spec = this.toSpec(request);
-    return spec && spec.type === 'git' ? this._fetch.bind(this) : null;
+    return spec && spec.type === 'git';
   }
 
-  async _fetch(request) {
+  async handle(request) {
     const spec = this.toSpec(request);
     if (!spec.tool) {
       // shortcut. if there is no tool to run then no need to get the repo
       request.document = {};
+      request.contentOrigin = 'origin';
       return request;
     }
     const sourceSpec = this._toSourceSpec(spec);

--- a/providers/fetch/npmFetch.js
+++ b/providers/fetch/npmFetch.js
@@ -12,16 +12,12 @@ const providerMap = {
 
 class NpmFetch extends BaseHandler {
 
-  get schemaVersion() {
-    return 1;
-  }
-
-  getHandler(request, type = request.type) {
+  canHandle(request, type = request.type) {
     const spec = this.toSpec(request);
-    return spec && spec.type === 'npm' ? this._fetch.bind(this) : null;
+    return spec && spec.type === 'npm';
   }
 
-  async _fetch(request) {
+  async handle(request) {
     const spec = this.toSpec(request);
     // if there is no revision, return an empty doc. The processor will find
     const metadata = await this._getMetadata(request);
@@ -32,7 +28,7 @@ class NpmFetch extends BaseHandler {
     const file = this._createTempFile(request);
     var options = {
       method: 'GET',
-      uri,
+      uri
     };
     return new Promise((resolve, reject) => {
       nodeRequest(options, (error, response, body) => {

--- a/providers/filter/filter.js
+++ b/providers/filter/filter.js
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+const BaseHandler = require('../../lib/baseHandler');
+
+class StandardFilter extends BaseHandler {
+
+  constructor(options, processors) {
+    super(options);
+    this.processors = processors;
+  }
+
+  shouldFetchMissing(request, spec) {
+    return request.policy.shouldFetchMissing(request)
+  }
+
+  shouldFetch(request, spec) {
+    return !request.document || this.shouldProcess(request, spec);
+  }
+
+  shouldProcess(request, spec) {
+    const processor = this._getProcessor(request, this.processors);
+    return processor.shouldProcess(request);
+  }
+
+  _getProcessor(request) {
+    return this.processors.filter(processor => processor.canHandle(request))[0];
+  }
+}
+
+module.exports = (options, processors) => new StandardFilter(options, processors);

--- a/providers/index.js
+++ b/providers/index.js
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 module.exports = {
+  filter: {
+    provider: 'filter',
+    filter: require('./filter/filter')
+  },
   fetch: {
+    cdDispatch: require('./fetch/dispatcher'),
     git: require('./fetch/gitCloner'),
     npm: require('./fetch/npmFetch')
   },

--- a/providers/process/source.js
+++ b/providers/process/source.js
@@ -10,16 +10,16 @@ class SourceProcessor extends BaseHandler {
   }
 
   get toolSpec() {
-    return { tool: 'clearlydescribed', toolVersion: 1 };
+    return { tool: 'clearlydescribed', toolVersion: this.schemaVersion };
   }
 
-  getHandler(request, type = request.type) {
+  canHandle(request, type = request.type) {
     const spec = this.toSpec(request);
     // if there is no tool and it is a source related request, it's for us
-    return (!spec.tool && ['git'].includes(type)) ? this._process.bind(this) : null;
+    return !spec.tool && ['git'].includes(type);
   }
 
-  _process(request) {
+  handle(request) {
     const { document, spec } = super._process(request);
     this.addBasicToolLinks(request, spec);
     this.linkAndQueueTool(request, 'scancode', 'scancode');

--- a/providers/process/top.js
+++ b/providers/process/top.js
@@ -12,16 +12,16 @@ class TopProcessor extends BaseHandler {
   }
 
   get toolSpec() {
-    return { tool: 'toploader', toolVersion: 1 };
+    return { tool: 'toploader', toolVersion: this.schemaVersion };
   }
 
-  getHandler(request, type = request.type) {
+  canHandle(request, type = request.type) {
     const spec = this.toSpec(request);
     // if there is no tool and it is a source related request, it's for us
-    return spec.tool === 'top' ? this._process.bind(this) : null;
+    return spec.tool === 'top';
   }
 
-  _process(request) {
+  handle(request) {
     const { document, spec } = super._process(request);
     this.addBasicToolLinks(request, spec);
     switch (spec.type) {


### PR DESCRIPTION
Implement checks for pre-existing results when processing a request. There is a bit more change here than would otherwise be expected as the nature (and identity) of the output depends on the processors used for  the request. So the request itself is not enough to form the cache key.

So to do this we have to 
* plug in a "dispatcher" for the fetcher that consults with the processors to see what will happen. We could have baked that into the base crawler but that is not necessarily generalized.
* generalize some of the processor logic so we can ask questions rather than simply run the processors. For example, we need to as for their `toolSpec` for use in forming the storage key (aka URN)
* factor out some of the filtering logic so it is not assumed by the base crawler. 

There are a couple of updates to the base crawler to enable these changes but for the most part this is within the architecture.