### PR TITLE
rationalize request types

### DIFF
--- a/config/cdConfig.js
+++ b/config/cdConfig.js
@@ -22,7 +22,8 @@ module.exports =
     provider: 'memory',  // change this to redis if/when we want distributed config
     searchPath: [module],
     crawler: {
-      count: 1
+      count: 1,
+      drainPulse: 1
     },
     filter: {
       provider: 'filter',

--- a/config/cdConfig.js
+++ b/config/cdConfig.js
@@ -33,9 +33,10 @@ module.exports =
       dispatcher: 'cdDispatch',
       cdDispatch: {},
       git: {},
-      npm: {}
+      npmjs: {}
     },
     process: {
+      package: {},
       source: {},
       scancode: {
         installDir: config.get('SCANCODE_HOME') || 'C:\\installs\\scancode-toolkit-2.2.1',

--- a/config/map.js
+++ b/config/map.js
@@ -10,25 +10,40 @@ function neighbors() {
 
 const scancode = self;
 
+// default ClearlyDefined tool
+const cd = self;
+
 const source = {
   _type: 'source',
-  scancode
+  scancode,
+  cd
 }
 
 const npm = {
   _type: 'npm',
-  source
+  source,
+  scancode,
+  cd
 };
 
 const maven = {
   _type: 'maven',
-  source
+  source,
+  cd
+};
+
+const package = {
+  _type: 'package',
+  npm,
+  maven
 };
 
 const entities = {
   self,
   neighbors,
   source,
+  package,
+  cd,
   scancode,
   npm,
   maven

--- a/lib/baseHandler.js
+++ b/lib/baseHandler.js
@@ -5,6 +5,7 @@ const tmp = require('tmp');
 const semver = require('semver');
 const EntitySpec = require('../lib/entitySpec');
 
+tmp.setGracefulCleanup();
 const tmpOptions = {
   unsafeCleanup: true,
   template: (process.platform === 'win32' ? 'c:/temp/' : '/tmp/') + 'cd-XXXXXX'
@@ -23,6 +24,10 @@ class BaseHandler {
       unsafeCleanup: true,
       template: tmpBase + 'cd-XXXXXX'
     };
+  }
+
+  shouldFetch(request) {
+    return true;
   }
 
   canHandle(request) {
@@ -98,16 +103,19 @@ class BaseHandler {
     return newSpec.toUrn();
   }
 
-  linkAndQueue(request, name, spec) {
+  linkAndQueue(request, name, spec = null) {
+    spec = spec || this.toSpec(request);
     request.linkResource(name, spec.toUrn());
-    request.queue(spec.type, spec.toUrl(), request.getNextPolicy(name));
+    request.queue(name, spec.toUrl(), request.getNextPolicy(name));
   }
 
-  linkAndQueueTool(request, name, tool) {
+  linkAndQueueTool(request, name, tool = name) {
     const spec = this.toSpec(request);
+    const url = spec.toUrl();
     spec.tool = tool;
-    request.linkCollection(name, spec.toUrn());
-    request.queue(spec.type, spec.toUrl(), request.getNextPolicy(name));
+    const urn = spec.toUrn();
+    request.linkCollection(name, urn);
+    request.queue(tool, url, request.getNextPolicy(name));
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,18 @@
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
+    "amqp10": {
+      "version": "github:noodlefrenzy/node-amqp10#187810515042a23b258afba9300e80f2416141d7",
+      "requires": {
+        "bl": "1.2.1",
+        "bluebird": "3.5.1",
+        "buffer-builder": "0.2.0",
+        "debug": "2.6.9",
+        "lodash": "4.17.4",
+        "node-int64": "0.4.0",
+        "stately.js": "1.3.0"
+      }
+    },
     "amqplib": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.5.2.tgz",
@@ -294,6 +306,30 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "azure-common": {
+      "version": "github:geneh/azure-common#fdbd6c42425c276820e8d1aab9036fc08784bb84",
+      "requires": {
+        "dateformat": "1.0.2-1.2.3",
+        "duplexer": "0.1.1",
+        "envconf": "0.0.4",
+        "request": "2.74.0",
+        "through": "2.3.8",
+        "tunnel": "0.0.5",
+        "underscore": "1.4.4",
+        "validator": "3.22.2",
+        "xml2js": "0.2.7",
+        "xmlbuilder": "0.4.3"
+      }
+    },
+    "azure-sb": {
+      "version": "github:geneh/azure-sb#a92aafcc82d27eb5abde7d33a4430586aca68d8a",
+      "requires": {
+        "azure-common": "github:geneh/azure-common#fdbd6c42425c276820e8d1aab9036fc08784bb84",
+        "mpns": "2.0.1",
+        "underscore": "1.4.4",
+        "wns": "0.5.3"
+      }
     },
     "azure-storage": {
       "version": "1.4.0",
@@ -2081,7 +2117,7 @@
       }
     },
     "ghcrawler": {
-      "version": "github:microsoft/ghcrawler#d1de89ec5127b4cd75f8f57860fca5986ebf0f93",
+      "version": "github:microsoft/ghcrawler#1b89ce774a40a0be05e7c7d430782d2cf9878cb2",
       "requires": {
         "amqp10": "github:noodlefrenzy/node-amqp10#187810515042a23b258afba9300e80f2416141d7",
         "amqplib": "0.5.2",
@@ -2122,42 +2158,6 @@
         "winston-azure-application-insights": "1.1.1"
       },
       "dependencies": {
-        "amqp10": {
-          "version": "github:noodlefrenzy/node-amqp10#187810515042a23b258afba9300e80f2416141d7",
-          "requires": {
-            "bl": "1.2.1",
-            "bluebird": "3.5.1",
-            "buffer-builder": "0.2.0",
-            "debug": "2.6.9",
-            "lodash": "4.17.4",
-            "node-int64": "0.4.0",
-            "stately.js": "1.3.0"
-          }
-        },
-        "azure-common": {
-          "version": "github:geneh/azure-common#fdbd6c42425c276820e8d1aab9036fc08784bb84",
-          "requires": {
-            "dateformat": "1.0.2-1.2.3",
-            "duplexer": "0.1.1",
-            "envconf": "0.0.4",
-            "request": "2.74.0",
-            "through": "2.3.8",
-            "tunnel": "0.0.5",
-            "underscore": "1.4.4",
-            "validator": "3.22.2",
-            "xml2js": "0.2.7",
-            "xmlbuilder": "0.4.3"
-          }
-        },
-        "azure-sb": {
-          "version": "github:geneh/azure-sb#a92aafcc82d27eb5abde7d33a4430586aca68d8a",
-          "requires": {
-            "azure-common": "github:geneh/azure-common#fdbd6c42425c276820e8d1aab9036fc08784bb84",
-            "mpns": "2.0.1",
-            "underscore": "1.4.4",
-            "wns": "0.5.3"
-          }
-        },
         "extend": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
@@ -2172,19 +2172,6 @@
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
           "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
-        },
-        "redis-rate-limiter": {
-          "version": "github:jeffmcaffer/redis-rate-limiter#9d8dd4b7b1d91edf5c9b0b4993c3d0ef68339e5d",
-          "requires": {
-            "moment": "2.17.1"
-          },
-          "dependencies": {
-            "moment": {
-              "version": "2.17.1",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.17.1.tgz",
-              "integrity": "sha1-/tlQYGPzaxDwZsi1mhRNf66+HYI="
-            }
-          }
         }
       }
     },
@@ -4249,6 +4236,19 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
       "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
+    },
+    "redis-rate-limiter": {
+      "version": "github:jeffmcaffer/redis-rate-limiter#9d8dd4b7b1d91edf5c9b0b4993c3d0ef68339e5d",
+      "requires": {
+        "moment": "2.17.1"
+      },
+      "dependencies": {
+        "moment": {
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.17.1.tgz",
+          "integrity": "sha1-/tlQYGPzaxDwZsi1mhRNf66+HYI="
+        }
+      }
     },
     "redlock": {
       "version": "2.0.1",

--- a/providers/fetch/dispatcher.js
+++ b/providers/fetch/dispatcher.js
@@ -13,7 +13,7 @@ class FetchDispatcher extends BaseHandler {
     this.filter = filter;
   }
 
-  canHandle(request, type = request.type) {
+  canHandle(request) {
     // handle all fetch requests
     return true;
   }

--- a/providers/fetch/gitCloner.js
+++ b/providers/fetch/gitCloner.js
@@ -7,7 +7,7 @@ const SourceSpec = require('../../lib/sourceSpec');
 
 class GitHubCloner extends BaseHandler {
 
-  canHandle(request, type = request.type) {
+  canHandle(request) {
     const spec = this.toSpec(request);
     return spec && spec.type === 'git';
   }

--- a/providers/fetch/gitCloner.js
+++ b/providers/fetch/gitCloner.js
@@ -5,21 +5,15 @@ const BaseHandler = require('../../lib/baseHandler');
 const { exec } = require('child_process');
 const SourceSpec = require('../../lib/sourceSpec');
 
-class GitHubCloner extends BaseHandler {
+class GitCloner extends BaseHandler {
 
   canHandle(request) {
     const spec = this.toSpec(request);
-    return spec && spec.type === 'git';
+    return request.type !== 'source' && spec && spec.type === 'git';
   }
 
   async handle(request) {
     const spec = this.toSpec(request);
-    if (!spec.tool) {
-      // shortcut. if there is no tool to run then no need to get the repo
-      request.document = {};
-      request.contentOrigin = 'origin';
-      return request;
-    }
     const sourceSpec = this._toSourceSpec(spec);
     const options = { version: sourceSpec.revision };
     const dir = this._createTempDir(request);
@@ -53,4 +47,4 @@ class GitHubCloner extends BaseHandler {
   }
 }
 
-module.exports = options => new GitHubCloner(options);
+module.exports = options => new GitCloner(options);

--- a/providers/fetch/npmFetch.js
+++ b/providers/fetch/npmFetch.js
@@ -12,7 +12,7 @@ const providerMap = {
 
 class NpmFetch extends BaseHandler {
 
-  canHandle(request, type = request.type) {
+  canHandle(request) {
     const spec = this.toSpec(request);
     return spec && spec.type === 'npm';
   }

--- a/providers/index.js
+++ b/providers/index.js
@@ -9,9 +9,10 @@ module.exports = {
   fetch: {
     cdDispatch: require('./fetch/dispatcher'),
     git: require('./fetch/gitCloner'),
-    npm: require('./fetch/npmFetch')
+    npmjs: require('./fetch/npmjsFetch')
   },
   process: {
+    package: require('./process/package'),
     source: require('./process/source'),
     scancode: require('./process/scancode'),
     npm: require('./process/npmExtract'),

--- a/providers/process/package.js
+++ b/providers/process/package.js
@@ -3,7 +3,7 @@
 
 const BaseHandler = require('../../lib/baseHandler');
 
-class SourceProcessor extends BaseHandler {
+class PackageProcessor extends BaseHandler {
 
   get schemaVersion() {
     return 1;
@@ -19,15 +19,16 @@ class SourceProcessor extends BaseHandler {
 
   canHandle(request) {
     const spec = this.toSpec(request);
-    return request.type === 'source' && spec && ['git'].includes(spec.type);
+    return request.type === 'package' && spec && ['npm'].includes(spec.type);
   }
 
   handle(request) {
     const { document, spec } = super._process(request);
     this.addBasicToolLinks(request, spec);
-    this.linkAndQueueTool(request, 'scancode');
-    return document;
+    this.linkAndQueueTool(request, spec.type);
+    request.markNoSave();
+    return request;
   }
 }
 
-module.exports = options => new SourceProcessor(options);
+module.exports = options => new PackageProcessor(options);

--- a/providers/process/scancode.js
+++ b/providers/process/scancode.js
@@ -27,8 +27,7 @@ class ScanCodeProcessor extends BaseHandler {
   }
 
   canHandle(request) {
-    const spec = this.toSpec(request);
-    return spec && spec.tool === 'scancode';
+    return request.type === 'scancode';
   }
 
   async handle(request) {

--- a/providers/process/source.js
+++ b/providers/process/source.js
@@ -16,7 +16,7 @@ class SourceProcessor extends BaseHandler {
   canHandle(request, type = request.type) {
     const spec = this.toSpec(request);
     // if there is no tool and it is a source related request, it's for us
-    return !spec.tool && ['git'].includes(type);
+    return type === 'source' && !spec.tool && ['git'].includes(spec.type);
   }
 
   handle(request) {

--- a/providers/process/top.js
+++ b/providers/process/top.js
@@ -16,9 +16,8 @@ class TopProcessor extends BaseHandler {
   }
 
   canHandle(request, type = request.type) {
-    const spec = this.toSpec(request);
     // if there is no tool and it is a source related request, it's for us
-    return spec.tool === 'top';
+    return type === 'top';
   }
 
   handle(request) {

--- a/providers/process/top.js
+++ b/providers/process/top.js
@@ -15,19 +15,19 @@ class TopProcessor extends BaseHandler {
     return { tool: 'toploader', toolVersion: this.schemaVersion };
   }
 
-  canHandle(request, type = request.type) {
-    // if there is no tool and it is a source related request, it's for us
-    return type === 'top';
+  canHandle(request) {
+    const spec = this.toSpec(request);
+    return request.type === 'top' && spec && spec.provider === 'npmjs';
   }
 
   handle(request) {
     const { document, spec } = super._process(request);
     this.addBasicToolLinks(request, spec);
-    switch (spec.type) {
-      case 'npm':
+    switch (spec.provider) {
+      case 'npmjs':
         return this._processTopNpms(request);
       default:
-        return request;
+        throw new Error(`Unknown provider type for 'top' request: ${spec.provider}`);
     }
   }
 


### PR DESCRIPTION
See issue #34 

The request type was hard to understand. Now it relates to the type of resource you ensure is available. For example, if you want the `scancode` output for an npm then queue up a request of type `scancode` with the url identifying the npm. Note that the npm itself might be on GitHub or npmjs but that is handled by the url.

The URL also need (can) not have the tool segments when queuing the request. That shows up in the service REST api and the URN but not here. different concerns.

This is cleaner and has a better chance of being understood by folks.

For added fun, this PR also hooks up scancode as a possible tool to run on an npm itself.
