### PR TITLE
Fix expression to determine file store location

### DIFF
--- a/config/cdConfig.js
+++ b/config/cdConfig.js
@@ -14,7 +14,7 @@ const azblob = {
 }
 
 const file = {
-  location: config.get('FILE_STORE_LOCATION') || process.platform === 'win32' ? 'c:/temp/cd' : '/tmp/cd'
+  location: config.get('FILE_STORE_LOCATION') || (process.platform === 'win32' ? 'c:/temp/cd' : '/tmp/cd')
 };
 
 module.exports =


### PR DESCRIPTION
The expression requires additional paranthesis, otherwise it always
evalutes to "c:/temp/cd" if a FILE_STORE_LOCATION is configured.