### PR TITLE
update VSTS build integration

### DIFF
--- a/config/cdConfig.js
+++ b/config/cdConfig.js
@@ -22,7 +22,7 @@ module.exports =
     provider: 'memory',  // change this to redis if/when we want distributed config
     searchPath: [module],
     crawler: {
-      count: 1
+      count: 2
     },
     filter: {
       provider: 'filter',
@@ -44,10 +44,11 @@ module.exports =
       scancode: {
         installDir: config.get('SCANCODE_HOME') || 'C:\\installs\\scancode-toolkit-2.2.1',
         options: ['--copyright', '--license', '--info', '--diag', '--only-findings', ' --strip-root', '--quiet'],
-        timeout: 300,
-        processes: 3,
+        timeout: 1000,
+        processes: 2,
         format: 'json-pp',
-        maxSize: 30 * 1024, // Maximum repo size in KB after which scancode would run in build and not directly in crawler
+        maxCount: 1000,  // Maximum file count in repo for local processing. Above this scanning is done as a build
+        maxSize: 5 * 1024, // Maximum repo size in KB after which scancode would run in build and not directly in crawler
         build: {
           crawlerUrl: config.get('CRAWLER_SERVICE_URL') || 'http://localhost:5000',
           crawlerAuthToken: config.get('CRAWLER_SERVICE_AUTH_TOKEN') || 'secret',

--- a/lib/baseHandler.js
+++ b/lib/baseHandler.js
@@ -105,7 +105,11 @@ class BaseHandler {
 
   addBasicToolLinks(request, spec) {
     request.linkResource('self', this.getUrnFor(request, spec));
-    request.linkSiblings(spec.toUrn());
+    // create a new URN for the tool siblings. This should not have a version but should have the tool name
+    const newSpec = new EntitySpec(spec.type, spec.provider, spec.namespace, spec.name, spec.revision, spec.tool);
+    newSpec.tool = newSpec.tool || this.toolSpec.tool;
+    delete newSpec.toolVersion;
+    request.linkSiblings(newSpec.toUrn());
   }
 
   getUrnFor(request, spec = null) {

--- a/lib/build/vsts.js
+++ b/lib/build/vsts.js
@@ -16,7 +16,7 @@ class VstsBuild {
     this.vstsBuild = connection.getBuildApi();
   }
 
-  async queueBuild(document, spec, requestUrl) {
+  async queueBuild(request, spec) {
     const definitions = await this.vstsBuild.getDefinitions(this.options.project, this.options.definitionName);
     let definitionId = definitions && definitions[0] ? definitions[0].id : null;
     if (!definitionId) {
@@ -29,7 +29,8 @@ class VstsBuild {
       parameters: JSON.stringify({
         sourceUrl: `https://github.com/${spec.namespace}/${spec.name}.git`,
         sourceCommit: spec.revision,
-        callbackCommand: this._getCallbackCommand(requestUrl)
+        callbackCommand: this._getCallbackCommand(request.url),
+        request: JSON.stringify(JSON.stringify({ type: request.type, url: request.url }))
       })
     };
     return await this.vstsBuild.queueBuild(build, this.options.project);
@@ -77,6 +78,10 @@ class VstsBuild {
         sourceUrl: {
           value: '',
           allowOverride: true
+        },
+        request: {
+          value: '',
+          allowOverride: true
         }
       },
       build: [
@@ -92,7 +97,7 @@ class VstsBuild {
           inputs: {
             containerregistrytype: 'Azure Container Registry',
             azureSubscriptionEndpoint: this.options.azureSubscriptionEndpoint,
-            azureContainerRegistry: this.options.azureContainerRegistry,
+            azureContainerRegistry: JSON.stringify(this.options.azureContainerRegistry),
             action: 'Run an image',
             imageName: 'clearlydefined/tool-images/scancode:latest',
             qualifyImageName: 'true',
@@ -100,6 +105,20 @@ class VstsBuild {
             envVars: 'SOURCE_URL=$(sourceUrl)\nSOURCE_COMMIT=$(sourceCommit)\nCALLBACK_COMMAND=$(callbackCommand)',
             detached: 'false',
             restartPolicy: 'no'
+          }
+        },
+        {
+          enabled: true,
+          displayName: 'Request recorder',
+          refName: 'ShellScript1',
+          task: {
+            id: '6c731c3c-3c68-459a-a5c9-bde6e6595b5b',
+            versionSpec: '3.*',
+            definitionType: 'task'
+          },
+          inputs: {
+            targetType: 'inline',
+            script: 'mkdir $(Agent.BuildDirectory)/output\necho $(request) > $(Agent.BuildDirectory)/output/request.json\n'
           }
         },
         {
@@ -115,7 +134,8 @@ class VstsBuild {
             targetType: 'inline',
             script: 'mkdir $(Agent.BuildDirectory)/output\n\nif [ -f $(Agent.BuildDirectory)/scancode.json ]\nthen\n    mv $(Agent.BuildDirectory)/scancode.json $(Agent.BuildDirectory)/output/scancode.json\nelse\n    ERRORED_TASK_URL=$SYSTEM_TASKDEFINITIONSURI$SYSTEM_TEAMPROJECT/_apis/build/builds/$BUILD_BUILDID/logs/4\n    echo \"{\\\"error\\\":\\\"scancode failed $ERRORED_TASK_URL\\\"}\" > $(Agent.BuildDirectory)/output/error.json\nfi'
           }
-        }, {
+        },
+        {
           enabled: true,
           displayName: 'Publish Artifact: output',
           refName: 'PublishBuildArtifacts1',
@@ -129,7 +149,8 @@ class VstsBuild {
             ArtifactType: 'Container',
             TargetPath: '\\\\my\\share\\$(Build.DefinitionName)\\$(Build.BuildNumber)'
           }
-        }, {
+        },
+        {
           enabled: true,
           displayName: 'Execute callback command',
           refName: 'ShellScript1',

--- a/package-lock.json
+++ b/package-lock.json
@@ -629,7 +629,7 @@
         "on-finished": "2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.15"
+        "type-is": "1.6.16"
       },
       "dependencies": {
         "qs": {
@@ -1088,7 +1088,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "0.10.38"
+        "es5-ext": "0.10.39"
       }
     },
     "dashdash": {
@@ -1424,9 +1424,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.38",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.38.tgz",
-      "integrity": "sha512-jCMyePo7AXbUESwbl8Qi01VSH2piY9s/a3rSU/5w/MlTIx8HPL1xn2InGN8ejt/xulcJgnTO7vqNtOAxzYd2Kg==",
+      "version": "0.10.39",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.39.tgz",
+      "integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
       "requires": {
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
@@ -1438,7 +1438,7 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.38",
+        "es5-ext": "0.10.39",
         "es6-symbol": "3.1.1"
       }
     },
@@ -1448,7 +1448,7 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.38",
+        "es5-ext": "0.10.39",
         "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -1466,7 +1466,7 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.38",
+        "es5-ext": "0.10.39",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -1478,7 +1478,7 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.38"
+        "es5-ext": "0.10.39"
       }
     },
     "es6-weak-map": {
@@ -1487,7 +1487,7 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.38",
+        "es5-ext": "0.10.39",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -1760,7 +1760,7 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.38"
+        "es5-ext": "0.10.39"
       }
     },
     "eventemitter2": {
@@ -1806,7 +1806,7 @@
         "serve-static": "1.13.1",
         "setprototypeof": "1.1.0",
         "statuses": "1.3.1",
-        "type-is": "1.6.15",
+        "type-is": "1.6.16",
         "utils-merge": "1.0.1",
         "vary": "1.1.2"
       },
@@ -2492,11 +2492,6 @@
       "requires": {
         "ansi-regex": "2.1.1"
       }
-    },
-    "has-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
     },
     "has-flag": {
       "version": "1.0.0",
@@ -3189,7 +3184,7 @@
       "integrity": "sha1-VzcEUIX1XrRVxosf9OvAG9UOiDA=",
       "requires": {
         "JSV": "4.0.2",
-        "nomnom": "1.8.1"
+        "nomnom": "2.0.0"
       }
     },
     "jsonparse": {
@@ -3729,40 +3724,9 @@
       "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
     },
     "nomnom": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-      "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
-      "requires": {
-        "chalk": "0.4.0",
-        "underscore": "1.6.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
-        },
-        "chalk": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-          "requires": {
-            "ansi-styles": "1.0.0",
-            "has-color": "0.1.7",
-            "strip-ansi": "0.1.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
-        },
-        "underscore": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
-        }
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-2.0.0.tgz",
+      "integrity": "sha512-frks+w18/6p+nAJ+zd6DdPpBytjt4tdTVnRY9nK4GoiCtG4gVgLs4MR+LCm83Bq4JtN6ol7a10BSPsS/qE+2dA=="
     },
     "nopt": {
       "version": "3.0.6",
@@ -4213,6 +4177,24 @@
           "version": "15001.1001.0-dev-harmony-fb",
           "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
           "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk="
+        }
+      }
+    },
+    "recursive-readdir": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.1.tgz",
+      "integrity": "sha1-kO8jHQd4xc4JPJpI105cVCLROpk=",
+      "requires": {
+        "minimatch": "3.0.3"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         }
       }
     },
@@ -5114,12 +5096,27 @@
       "dev": true
     },
     "type-is": {
-      "version": "1.6.15",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.17"
+        "mime-types": "2.1.18"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.33.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+          "requires": {
+            "mime-db": "1.33.0"
+          }
+        }
       }
     },
     "typed-rest-client": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "painless-config": "^0.1.0",
     "parse-github-url": "^1.0.2",
     "promise-retry": "^1.1.1",
+    "recursive-readdir": "^2.2.1",
     "request-promise-native": "^1.0.5",
     "requestretry": "^1.12.2",
     "tmp": "0.0.33",

--- a/providers/fetch/mavenFetch.js
+++ b/providers/fetch/mavenFetch.js
@@ -43,20 +43,16 @@ class MavenFetch extends BaseHandler {
   }
 
   async _getArtifact(spec, destination) {
-    const extension = spec.type === 'sourcearchive' ? '-sources.jar' : '.pom';
-    const uri = this._buildUrl(spec, extension);
-    var options = {
-      method: 'GET',
-      uri
-    };
     return new Promise((resolve, reject) => {
-      nodeRequest(options, (error, response) => {
+      const extension = spec.type === 'sourcearchive' ? '-sources.jar' : '.pom';
+      nodeRequest.get(this._buildUrl(spec, extension), (error, response) => {
         if (error)
           return reject(error);
-        if (response.statusCode === 200 || response.statusCode === 404)
-          return resolve(response.statusCode);
-        reject(new Error(`${response.statusCode} ${response.statusMessage}`))
-      }).pipe(fs.createWriteStream(destination));
+        if (response.statusCode === 404)
+          resolve(response.statusCode);
+        if (response.statusCode !== 200)
+          reject(new Error(`${response.statusCode} ${response.statusMessage}`))
+      }).pipe(fs.createWriteStream(destination).on('finish', () => resolve(null)));
     });
   }
 

--- a/providers/fetch/npmjsFetch.js
+++ b/providers/fetch/npmjsFetch.js
@@ -33,19 +33,13 @@ class NpmFetch extends BaseHandler {
   }
 
   async _getPackage(spec, destination) {
-    const uri = this._buildUrl(spec);
-    var options = {
-      method: 'GET',
-      uri
-    };
     return new Promise((resolve, reject) => {
-      nodeRequest(options, (error, response) => {
+      nodeRequest.get(this._buildUrl(spec), (error, response) => {
         if (error)
           return reject(error);
-        if (response.statusCode === 200)
-          return resolve(null);
-        reject(new Error(`${response.statusCode} ${response.statusMessage}`))
-      }).pipe(fs.createWriteStream(destination));
+        if (response.statusCode !== 200)
+          reject(new Error(`${response.statusCode} ${response.statusMessage}`))
+      }).pipe(fs.createWriteStream(destination).on('finish', () => resolve(null)));
     });
   }
 


### PR DESCRIPTION
When we run scans as VSTS builds this PR
* makes the build output more self-described so the outputs can simply be downloaded and ingested (if needed)
* generalizes the way "size" is computed to determine if the build approach should be used. Rather than using git repo size, we now look on disk at the number of files and the size of the files. I've made guesses at what makes sense to run inline vs build but we'll have to see that over time.