### PR TITLE
Remove "All Rights Reserved."

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: MIT
 
 #FROM node:8-alpine # switch back to node:8-alpine after removing Scancode

--- a/config/cdConfig.js
+++ b/config/cdConfig.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const config = require('painless-config');

--- a/config/cdMemoryConfig.js
+++ b/config/cdMemoryConfig.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 module.exports =

--- a/config/map.js
+++ b/config/map.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 // Map building blocks

--- a/lib/baseHandler.js
+++ b/lib/baseHandler.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const tmp = require('tmp');

--- a/lib/build/vsts.js
+++ b/lib/build/vsts.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const vsts = require('vso-node-api');

--- a/lib/entitySpec.js
+++ b/lib/entitySpec.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const NAMESPACE = 0x4;

--- a/lib/sourceDiscovery.js
+++ b/lib/sourceDiscovery.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const _ = require('lodash');

--- a/lib/sourceSpec.js
+++ b/lib/sourceSpec.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const EntitySpec = require('./entitySpec');

--- a/providers/fetch/dispatcher.js
+++ b/providers/fetch/dispatcher.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const BaseHandler = require('../../lib/baseHandler');

--- a/providers/fetch/gitCloner.js
+++ b/providers/fetch/gitCloner.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const BaseHandler = require('../../lib/baseHandler');

--- a/providers/fetch/mavenFetch.js
+++ b/providers/fetch/mavenFetch.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const BaseHandler = require('../../lib/baseHandler');

--- a/providers/fetch/npmjsFetch.js
+++ b/providers/fetch/npmjsFetch.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const BaseHandler = require('../../lib/baseHandler');

--- a/providers/filter/filter.js
+++ b/providers/filter/filter.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const BaseHandler = require('../../lib/baseHandler');

--- a/providers/index.js
+++ b/providers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 module.exports = {

--- a/providers/process/mavenExtract.js
+++ b/providers/process/mavenExtract.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const BaseHandler = require('../../lib/baseHandler');

--- a/providers/process/npmExtract.js
+++ b/providers/process/npmExtract.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const BaseHandler = require('../../lib/baseHandler');

--- a/providers/process/package.js
+++ b/providers/process/package.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const BaseHandler = require('../../lib/baseHandler');

--- a/providers/process/scancode.js
+++ b/providers/process/scancode.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const BaseHandler = require('../../lib/baseHandler');

--- a/providers/process/source.js
+++ b/providers/process/source.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const BaseHandler = require('../../lib/baseHandler');

--- a/providers/process/sourceExtract.js
+++ b/providers/process/sourceExtract.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const BaseHandler = require('../../lib/baseHandler');

--- a/providers/process/top.js
+++ b/providers/process/top.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const BaseHandler = require('../../lib/baseHandler');

--- a/providers/process/vsts.js
+++ b/providers/process/vsts.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const BaseHandler = require('../../lib/baseHandler');

--- a/providers/store/storeDispatcher.js
+++ b/providers/store/storeDispatcher.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 class StoreDispatcher{

--- a/providers/store/webhookDeltaStore.js
+++ b/providers/store/webhookDeltaStore.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const request = require('request-promise-native');

--- a/run.js
+++ b/run.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const config = require('painless-config');


### PR DESCRIPTION
After discussion at the TODO hackathon, it was agreed to remove
"All Rights Reserved" statements from copyright notices in order
to reduce potential confusion.