### PR TITLE
Resolve EISDIR error

### DIFF
--- a/lib/baseHandler.js
+++ b/lib/baseHandler.js
@@ -71,7 +71,10 @@ class BaseHandler {
   }
 
   decompress(source, destination) {
-    return decompress(source, destination)
+    return decompress(source, destination).catch(error => {
+      if (error.code === 'EISDIR') return Promise.resolve()
+      return Promise.reject(error)
+    })
   }
 
   toSpec(request) {


### PR DESCRIPTION
Address issue https://github.com/clearlydefined/crawler/issues/89
This error has been happening mostly for some of Maven Central artifacts with broken links in jar files.
decompress library is still able to decompress those archives when EISDIR error is encountered.