### PR TITLE
NPM name must be lower case

### DIFF
--- a/lib/entitySpec.js
+++ b/lib/entitySpec.js
@@ -8,7 +8,7 @@ const NONE = 0
 
 const toLowerCaseMap = {
   github: NAMESPACE | NAME,
-  npmjs: NONE,
+  npmjs: NAME,
   mavencentral: NONE,
   mavencentralsource: NONE,
   nuget: NAME


### PR DESCRIPTION
Tested with `{ "type": "npm", "url": "cd:/npm/npmjs/-/SlickGrid/2.3.3" }`
