### PR TITLE
add coordinates metadata to documents as they are processed

### DIFF
--- a/lib/baseHandler.js
+++ b/lib/baseHandler.js
@@ -10,6 +10,7 @@ const fs = require('fs')
 const path = require('path')
 const glob = require('glob')
 const shajs = require('sha.js')
+const { set } = require('lodash')
 
 tmp.setGracefulCleanup()
 const tmpOptions = {
@@ -89,8 +90,10 @@ class BaseHandler {
   }
 
   _process(request) {
+    const spec = this.toSpec(request)
     request.document._metadata.version = this.schemaVersion || 1
-    return { document: request.document, spec: this.toSpec(request) }
+    set(request, 'document._metadata.extra.coordinates', spec.toUrlPath())
+    return { document: request.document, spec }
   }
 
   _createTempFile(request) {


### PR DESCRIPTION
We originally wanted to store this right in `_metadata/coordinates` for files and `_metadata/extra/coordinates` for blobs.
I ended up leaving the coordinates in `extra` all the time - after investigating, the complexity of differentiating where to store this data at this point did not seem worth it