### PR TITLE
add missing await in npm extract

### DIFF
--- a/providers/process/npmExtract.js
+++ b/providers/process/npmExtract.js
@@ -33,7 +33,7 @@ class NpmExtract extends BaseHandler {
       const manifestLocation = this._getManifestLocation(location)
       const manifest = manifestLocation ? JSON.parse(fs.readFileSync(manifestLocation)) : null
       if (!manifest) console.log(`NPM without package.json: ${request.url}`)
-      this._createDocument(request, manifest, request.document.registryData)
+      await this._createDocument(request, manifest, request.document.registryData)
       await BaseHandler.addInterestingFiles(request.document, path.join(location, 'package'))
     }
     this.linkAndQueueTool(request, 'scancode')


### PR DESCRIPTION
In a refactoring a couple weeks ago an `await` got removed in `npmExtract`. This adds it back.

Also handling cases where nomos is not installed to clean up some errors on start. 