### PR TITLE
fix maven source url

### DIFF
--- a/lib/mavenCentral.js
+++ b/lib/mavenCentral.js
@@ -4,19 +4,21 @@
 const nodeRequest = require('request')
 const fs = require('fs')
 
+const sourceExtension = '-sources.jar'
+const pomExtension = '.pom'
 const providerMap = {
   mavencentral: 'https://search.maven.org/remotecontent?filepath='
 }
 
 function fetchPom(spec, destination) {
-  return _fetchFromMavenCentral(_buildMavenCentralUrl(spec, '.pom'), destination)
+  return _fetchFromMavenCentral(buildMavenCentralUrl(spec, pomExtension), destination)
 }
 
 function fetchSourcesJar(spec, destination) {
-  return _fetchFromMavenCentral(_buildMavenCentralUrl(spec, '-sources.jar'), destination)
+  return _fetchFromMavenCentral(buildMavenCentralUrl(spec, sourceExtension), destination)
 }
 
-function _buildMavenCentralUrl(spec, extension) {
+function buildMavenCentralUrl(spec, extension) {
   const fullName = `${spec.namespace}/${spec.name}`.replace(/\./g, '/')
   return `${providerMap[spec.provider]}${fullName}/${spec.revision}/${spec.name}-${spec.revision}${extension}`
 }
@@ -35,3 +37,6 @@ function _fetchFromMavenCentral(url, destination) {
 
 module.exports.fetchPom = fetchPom
 module.exports.fetchSourcesJar = fetchSourcesJar
+module.exports.buildMavenCentralUrl = buildMavenCentralUrl
+module.exports.sourceExtension = sourceExtension
+module.exports.pomExtension = pomExtension


### PR DESCRIPTION
Maven source urls were actually being stored as just group:artifactid. That is convenient but ultimately needs to be formulated as a url for the definition. Best to just compute it in the crawler where we have all the repo-specific info.