### PR TITLE
better error messages for 404ing npm packages

### DIFF
--- a/providers/fetch/npmjsFetch.js
+++ b/providers/fetch/npmjsFetch.js
@@ -60,7 +60,7 @@ class NpmFetch extends BaseHandler {
         json: true
       })
     } catch (exception) {
-      if (exception.statusCode !== 404)
+      if (exception.statusCode === 404)
         throw new Error(`404 npm not found - ${fullName} not found from ${baseUrl}`)
       throw exception
     }

--- a/providers/fetch/npmjsFetch.js
+++ b/providers/fetch/npmjsFetch.js
@@ -60,11 +60,9 @@ class NpmFetch extends BaseHandler {
         json: true
       })
     } catch (exception) {
-      if (exception.statusCode === 404) {
+      if (exception.statusCode !== 404)
         throw new Error(`404 npm not found - ${fullName} not found from ${baseUrl}`)
-      } else {
-        throw exception
-      }
+      throw exception
     }
     if (!registryData.versions) return null
     const version = spec.revision || this.getLatestVersion(Object.keys(registryData.versions))


### PR DESCRIPTION
Before:

```
    at Request.<anonymous> (/Users/dan/codes/clearlydefined/crawler/node_modules/request/request.js:1157:10)
    at emitOne (events.js:116:13)
    at Request.emit (events.js:211:7)
    at IncomingMessage.<anonymous> (/Users/dan/codes/clearlydefined/crawler/node_modules/request/request.js:1079:12)
    at Object.onceWrapper (events.js:313:30)
    at emitNone (events.js:111:20)
    at IncomingMessage.emit (events.js:208:7)
    at endReadableNT (_stream_readable.js:1064:12)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickCallback (internal/process/next_tick.js:180:9){"loopName":"0","cid":"6","root":"package@cd:/npm/npmjs/-/gasasdrpc/1.12.2","outcome":"Error","time":1095}
```

---

After:

```
Error: 404 npm not found - gasasdrpc not found from https://registry.npmjs.com
    at NpmFetch._getRegistryData (/Users/dan/codes/clearlydefined/crawler/providers/fetch/npmjsFetch.js:64:15)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7){"loopName":"0","cid":"3","root":"package@cd:/npm/npmjs/-/gasasdrpc/1.12.2","outcome":"Error","time":1337}
```
