### PR TITLE
fix for null reference with missing npmjs registry data

### DIFF
--- a/providers/fetch/npmjsFetch.js
+++ b/providers/fetch/npmjsFetch.js
@@ -5,7 +5,7 @@ const BaseHandler = require('../../lib/baseHandler')
 const nodeRequest = require('request')
 const requestPromise = require('request-promise-native')
 const fs = require('fs')
-const { clone } = require('lodash')
+const { clone, get } = require('lodash')
 
 const providerMap = {
   npmjs: 'https://registry.npmjs.com'
@@ -76,7 +76,7 @@ class NpmFetch extends BaseHandler {
   }
 
   _createDocument(dir, registryData) {
-    const releaseDate = registryData.releaseDate
+    const releaseDate = get(registryData, 'releaseDate')
     return { location: dir.name, registryData, releaseDate }
   }
 

--- a/test/unit/providers/fetch/npmjsFetch.js
+++ b/test/unit/providers/fetch/npmjsFetch.js
@@ -24,4 +24,15 @@ describe('npmjsFetch', () => {
     const casedSpec = NpmFetch({})._getCasedSpec(spec_nonnamespace, {})
     expect(!!casedSpec).to.be.false
   })
+
+  it('should create document with releaseDate', () => {
+    const document = NpmFetch({})._createDocument({ name: 'foo' }, { releaseDate: '01/01/2018' })
+    expect(document.location).to.eq('foo')
+    expect(document.releaseDate).to.eq('01/01/2018')
+  })
+
+  it('should create document with null registryData', () => {
+    const document = NpmFetch({})._createDocument({ name: 'foo' }, null)
+    expect(document.location).to.eq('foo')
+  })
 })


### PR DESCRIPTION
getting errors in the logs for this situation

```
TypeError: Cannot read property 'releaseDate' of null at NpmFetch._createDocument (/opt/service/providers/fetch/npmjsFetch.js:79:38) 
```