### PR TITLE
filter decompress files that end in `/`

### DIFF
--- a/lib/baseHandler.js
+++ b/lib/baseHandler.js
@@ -129,7 +129,9 @@ class BaseHandler {
   }
 
   decompress(source, destination) {
-    return decompress(source, destination)
+    return decompress(source, destination, {
+      filter: file => !file.path.endsWith('/')
+    })
   }
 
   toSpec(request) {


### PR DESCRIPTION
 - getting EISDIR errors during tmp cleanup
 - the file was getting wrongly unzipped as a file instead of a folder
 - this updates to just skip the folders
 - see https://github.com/kevva/decompress/issues/46