### PR TITLE
retain folder name when harvesting interesting files (fixes #170)

### DIFF
--- a/lib/baseHandler.js
+++ b/lib/baseHandler.js
@@ -41,24 +41,27 @@ class BaseHandler {
       .digest('hex')
   }
 
-  static addInterestingFiles(document, location) {
+  static addInterestingFiles(document, location, folder = '') {
     if (!location && location !== '') return null
     return new Promise((resolve, reject) => {
       glob(
         buildGlob(['license', 'notice', 'notices']),
-        { cwd: location, nocase: true, nodir: true },
+        { cwd: path.join(location, folder), nocase: true, nodir: true },
         (error, files) => {
           if (error) reject(error)
           if (files.length === 0) return resolve(null)
           Object.defineProperty(document, '_attachments', { value: [], enumerable: false })
-          Promise.all(files.map(async file => {
-            const filePath = path.join(location, file)
-            const attachment = fs.readFileSync(filePath, 'utf8')
-            const token = BaseHandler.computeToken(attachment)
-            const license = await BaseHandler.detectLicenses(filePath)
-            document._attachments.push({ path: file, token, attachment, license })
-            return { path: file, token, license }
-          })).then((interestingFiles) => {
+          Promise.all(
+            files.map(async file => {
+              const fullPath = path.join(location, folder, file)
+              const relativePath = path.join(folder, file)
+              const attachment = fs.readFileSync(fullPath, 'utf8')
+              const token = BaseHandler.computeToken(attachment)
+              const license = await BaseHandler.detectLicenses(fullPath)
+              document._attachments.push({ path: relativePath, token, attachment, license })
+              return { path: relativePath, token, license }
+            })
+          ).then(interestingFiles => {
             document.interestingFiles = interestingFiles
             resolve()
           })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1041,6 +1041,18 @@
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
           "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
         },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "recast": {
           "version": "0.11.23",
           "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
@@ -2318,13 +2330,14 @@
       }
     },
     "glob": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "requires": {
+        "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "2 || 3",
+        "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
@@ -2821,6 +2834,19 @@
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "has-flag": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
@@ -2927,6 +2953,18 @@
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "requires": {
             "graceful-readlink": ">= 1.0.0"
+          }
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "lodash": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "extract-zip": "^1.6.6",
     "ghcrawler": "github:microsoft/ghcrawler#jm/apicrawler",
     "ghrequestor": "^0.1.7",
+    "glob": "^7.1.3",
     "lodash": "^4.17.5",
     "moment": "^2.20.1",
     "morgan": "^1.9.0",

--- a/providers/process/npmExtract.js
+++ b/providers/process/npmExtract.js
@@ -15,7 +15,7 @@ class NpmExtract extends BaseHandler {
   }
 
   get schemaVersion() {
-    return '1.1.2'
+    return '1.1.3'
   }
 
   get toolSpec() {
@@ -39,7 +39,7 @@ class NpmExtract extends BaseHandler {
       const manifest = manifestLocation ? JSON.parse(fs.readFileSync(manifestLocation)) : null
       if (!manifest) console.log(`NPM without package.json: ${request.url}`)
       await this._createDocument(request, manifest, request.document.registryData)
-      await BaseHandler.addInterestingFiles(request.document, path.join(location, 'package'))
+      await BaseHandler.addInterestingFiles(request.document, location, 'package')
     }
     this.linkAndQueueTool(request, 'scancode')
     this.linkAndQueueTool(request, 'fossology')

--- a/test/unit/providers/fetch/nugetFetch.js
+++ b/test/unit/providers/fetch/nugetFetch.js
@@ -3,8 +3,6 @@
 
 const chai = require('chai')
 const NuGetFetch = require('../../../../providers/fetch/nugetFetch')({})
-
-const { describe, it } = require('mocha')
 const expect = chai.expect
 
 describe('NuGet fetch', () => {

--- a/test/unit/providers/store/attachmentStore.js
+++ b/test/unit/providers/store/attachmentStore.js
@@ -4,7 +4,6 @@
 const chai = require('chai')
 const expect = chai.expect
 const factory = require('../../../../providers/store/attachmentStoreFactory')
-const { describe, it } = require('mocha')
 const sinon = require('sinon')
 
 describe('AttachmentStore', () => {


### PR DESCRIPTION
The CD tool was dropping the 'package' prefix when collecting files from an NPM.
Other tools were retaining the prefix and it was causing a split of the same files showing in the UI.

We should strive to reflect the actual package structure

before:

![image](https://user-images.githubusercontent.com/5168796/47452838-02596980-d780-11e8-99a2-716fe18bc795.png)

after:

![image](https://user-images.githubusercontent.com/5168796/47452858-0e452b80-d780-11e8-8c02-aaca96628ec2.png)
