### PR TITLE
[Rust] Add Crates.io support

### DIFF
--- a/config/cdConfig.js
+++ b/config/cdConfig.js
@@ -28,7 +28,7 @@ module.exports = {
   fetch: {
     dispatcher: 'cdDispatch',
     cdDispatch: {},
-    crate: {},
+    cratesio: {},
     git: {},
     mavenCentral: {},
     npmjs: {},

--- a/config/cdConfig.js
+++ b/config/cdConfig.js
@@ -28,6 +28,7 @@ module.exports = {
   fetch: {
     dispatcher: 'cdDispatch',
     cdDispatch: {},
+    crate: {},
     git: {},
     mavenCentral: {},
     npmjs: {},
@@ -37,6 +38,7 @@ module.exports = {
   },
   process: {
     cdsource: {},
+    crate: { githubToken },
     maven: { githubToken },
     pypi: { githubToken },
     gem: { githubToken },

--- a/config/map.js
+++ b/config/map.js
@@ -29,6 +29,14 @@ const npm = {
   fossology
 }
 
+const crate = {
+  _type: 'crate',
+  source,
+  clearlydefined,
+  scancode,
+  fossology
+}
+
 const maven = {
   _type: 'maven',
   source,
@@ -58,6 +66,7 @@ const gem = {
 const package = {
   _type: 'package',
   npm,
+  crate,
   maven,
   nuget,
   pypi,
@@ -73,6 +82,7 @@ const entities = {
   scancode,
   fossology,
   npm,
+  crate,
   maven,
   nuget,
   pypi,

--- a/providers/fetch/crateFetch.js
+++ b/providers/fetch/crateFetch.js
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const { clone } = require('lodash')
+const BaseHandler = require('../../lib/baseHandler')
+const request = require('request-promise-native')
+const fs = require('fs')
+const path = require('path')
+
+class CrateFetch extends BaseHandler {
+  canHandle(request) {
+    const spec = this.toSpec(request)
+    return spec && spec.provider === 'cratesio'
+  }
+
+  async handle(request) {
+    const spec = this.toSpec(request)
+    const { manifest, version } = await this._getRegistryData(spec)
+    if (!version) return request
+    spec.revision = version.num
+    request.url = spec.toUrl()
+    const dir = this._createTempDir(request)
+    const location = await this._getPackage(dir, version)
+    request.document = {
+      registryData: version,
+      releaseDate: version.created_at,
+      location,
+      manifest
+    }
+    request.contentOrigin = 'origin'
+    if (version.crate) {
+      request.casedSpec = clone(spec)
+      request.casedSpec.name = version.crate
+    }
+    return request
+  }
+
+  async _getRegistryData(spec) {
+    let registryData
+    try {
+      registryData = await request({
+        url: `https://crates.io/api/v1/crates/${spec.name}`,
+        json: true
+      })
+    } catch (exception) {
+      if (exception.statusCode === 404) throw new Error(`404 crate not found - ${spec.name}`)
+      throw exception
+    }
+    if (!registryData.versions) return null
+    const version = spec.revision || this.getLatestVersion(registryData.versions.map(x => x.num))
+    return {
+      manifest: registryData.crate,
+      version: registryData.versions.find(x => x.num === version)
+    }
+  }
+
+  async _getPackage(dir, version) {
+    const zip = path.join(dir.name, 'crate.zip')
+    const crate = path.join(dir.name, 'crate')
+    return new Promise((resolve, reject) => {
+      request({ url: `https://crates.io${version.dl_path}`, json: false, encoding: null }).pipe(
+        fs
+          .createWriteStream(zip)
+          .on('finish', async () => {
+            await this.decompress(zip, crate)
+            resolve(path.join(crate, `${version.crate}-${version.num}`))
+          })
+          .on('error', reject)
+      )
+    })
+  }
+}
+
+module.exports = options => new CrateFetch(options)

--- a/providers/index.js
+++ b/providers/index.js
@@ -11,7 +11,7 @@ module.exports = {
   },
   fetch: {
     cdDispatch: require('./fetch/dispatcher'),
-    crate: require('./fetch/crateFetch'),
+    cratesio: require('./fetch/crateFetch'),
     git: require('./fetch/gitCloner'),
     mavenCentral: require('./fetch/mavenFetch'),
     npmjs: require('./fetch/npmjsFetch'),

--- a/providers/index.js
+++ b/providers/index.js
@@ -11,6 +11,7 @@ module.exports = {
   },
   fetch: {
     cdDispatch: require('./fetch/dispatcher'),
+    crate: require('./fetch/crateFetch'),
     git: require('./fetch/gitCloner'),
     mavenCentral: require('./fetch/mavenFetch'),
     npmjs: require('./fetch/npmjsFetch'),
@@ -20,6 +21,7 @@ module.exports = {
   },
   process: {
     cdsource: require('./process/sourceExtract'),
+    crate: require('./process/crateExtract'),
     gem: require('./process/gemExtract'),
     maven: require('./process/mavenExtract'),
     npm: require('./process/npmExtract'),

--- a/providers/process/crateExtract.js
+++ b/providers/process/crateExtract.js
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const BaseHandler = require('../../lib/baseHandler')
+const fs = require('fs')
+const { promisify } = require('util')
+const sourceDiscovery = require('../../lib/sourceDiscovery')
+const SourceSpec = require('../../lib/sourceSpec')
+
+class CrateExtract extends BaseHandler {
+  constructor(options, sourceFinder) {
+    super(options)
+    this.sourceFinder = sourceFinder
+  }
+
+  get schemaVersion() {
+    return '1.0.0'
+  }
+
+  get toolSpec() {
+    return { tool: 'clearlydefined', toolVersion: this.schemaVersion }
+  }
+
+  canHandle(request) {
+    const spec = this.toSpec(request)
+    return request.type === 'crate' && spec && spec.type === 'crate'
+  }
+
+  async handle(request) {
+    if (this.isProcessing(request)) {
+      const { document, spec } = super._process(request)
+      this.addBasicToolLinks(request, spec)
+      const location = request.document.location
+      const manifest = request.document.manifest
+      await this._createDocument(request, manifest, request.document.registryData)
+      await BaseHandler.addInterestingFiles(request.document, location)
+    }
+    this.linkAndQueueTool(request, 'scancode')
+    this.linkAndQueueTool(request, 'fossology')
+    if (request.document.sourceInfo) {
+      const sourceSpec = SourceSpec.fromObject(request.document.sourceInfo)
+      this.linkAndQueue(request, 'source', sourceSpec.toEntitySpec())
+    }
+  }
+
+  async _createDocument(request, manifest, registryData) {
+    request.document = { _metadata: request.document._metadata, manifest, registryData }
+    const sourceInfo = await this._discoverSource(manifest, registryData)
+    if (sourceInfo) request.document.sourceInfo = sourceInfo
+  }
+
+  _discoverSource(manifest, registryData) {
+    return this.sourceFinder(registryData.num, [manifest.repository], {
+      githubToken: this.options.githubToken
+    })
+  }
+}
+
+module.exports = (options, sourceFinder) => new CrateExtract(options, sourceFinder || sourceDiscovery)

--- a/providers/process/package.js
+++ b/providers/process/package.js
@@ -18,7 +18,7 @@ class PackageProcessor extends BaseHandler {
 
   canHandle(request) {
     const spec = this.toSpec(request)
-    return request.type === 'package' && spec && ['npm', 'maven', 'nuget', 'gem', 'pypi'].includes(spec.type)
+    return request.type === 'package' && spec && ['npm', 'crate', 'maven', 'nuget', 'gem', 'pypi'].includes(spec.type)
   }
 
   handle(request) {

--- a/test/unit/providers/fetch/crateFetch.js
+++ b/test/unit/providers/fetch/crateFetch.js
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const chai = require('chai')
+const CrateFetch = require('../../../../providers/fetch/crateFetch')
+const expect = chai.expect
+
+describe('crateFetch', () => {
+  it('should handle crate requests', () => {
+    const crateFetch = mockCrateFetch({})
+    expect(crateFetch.canHandle({ url: 'cd:/crate/cratesio/-/name/0.1.0' })).to.be.true
+    expect(crateFetch.canHandle({ url: 'cd:/npm/npmjs/-/name/0.1.0' })).to.be.false
+  })
+
+  it('should return when no version', async () => {
+    const crateFetch = mockCrateFetch({
+      registryData: () => {
+        return { manifest: null, version: null }
+      }
+    })
+
+    const request = await crateFetch.handle({ url: 'cd:/crate/cratesio/-/name/0.1.0' })
+    expect(request.url).to.eq('cd:/crate/cratesio/-/name/0.1.0')
+    expect(request.document).to.be.undefined
+    expect(request.casedSpec).to.be.undefined
+  })
+
+  it('should set latest version when found', async () => {
+    const crateFetch = mockCrateFetch({
+      registryData: () => {
+        return { manifest: {}, version: { num: '0.5.0', crate: 'name' } }
+      }
+    })
+
+    const request = await crateFetch.handle({ url: 'cd:/crate/cratesio/-/name/0.1.0' })
+    expect(request.url).to.eq('cd:/crate/cratesio/-/name/0.5.0')
+  })
+
+  it('should preserve case from registry', async () => {
+    const crateFetch = mockCrateFetch({
+      registryData: () => {
+        return { manifest: {}, version: { num: '0.1.0', crate: 'name' } }
+      }
+    })
+
+    const request = await crateFetch.handle({ url: 'cd:/crate/cratesio/-/naME/0.1.0' })
+    expect(request.casedSpec.name).to.eq('name')
+  })
+})
+
+function mockCrateFetch(options) {
+  const crateFetch = CrateFetch({})
+
+  if (options.registryData) {
+    crateFetch._getRegistryData = options.registryData
+  }
+
+  crateFetch._createTempDir = () => '/tmp'
+  crateFetch._getPackage = () => '/tmp/crate'
+
+  return crateFetch
+}

--- a/test/unit/providers/fetch/process/crateExtract.js
+++ b/test/unit/providers/fetch/process/crateExtract.js
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const chai = require('chai')
+const expect = chai.expect
+
+const CrateExtract = require('../../../../../providers/process/crateExtract')
+
+describe('crateExtract', () => {
+  it('handles only crates', () => {
+    const crateExtract = CrateExtract({})
+    expect(crateExtract.canHandle({ type: 'crate', url: 'cd:/crate/cratesio/-/name/0.1.0' })).to.be.true
+    expect(crateExtract.canHandle({ type: 'npm', url: 'cd:/npm/npmjs/-/name/0.1.0' })).to.be.false
+  })
+})

--- a/test/unit/providers/store/attachmentStore.js
+++ b/test/unit/providers/store/attachmentStore.js
@@ -4,7 +4,6 @@
 const chai = require('chai')
 const expect = chai.expect
 const factory = require('../../../../providers/store/attachmentStoreFactory')
-const { describe, it } = require('mocha')
 const sinon = require('sinon')
 
 describe('AttachmentStore', () => {


### PR DESCRIPTION
coordinates look like `crate/cratesio/-/insert_multiple/0.1.1`

The fetch does the following:

- get the data from the [crates.io](http://crates.io) API
- Picks out the right version and attaches to the document
- download the actual package
- save the package manifest to disk
- Pick out the releaseDate

The extract does the following:

- reads the package manifest
- runs the sourceFinder and queues source harvest
- Adds interesting files from the crate
- Queues scancode + fossology