### PR TITLE
Add support for FOSSology's Monk and Copyright tools 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ RUN gem install licensee -v 9.10.1 --no-rdoc --no-ri
 WORKDIR /opt
 RUN git clone https://github.com/fossology/fossology.git
 
+# See https://github.com/fossology/fossology/blob/faaaeedb9d08f00def00f9b8a68a5cffc5eaa657/utils/fo-installdeps#L103-L105
+# Additional libjsoncpp-dev https://github.com/fossology/fossology/blob/261d1a3e663b5fd20652a05b2d6360f4b31a17cb/src/copyright/mod_deps#L79-L80
 RUN apt-get update && apt-get install -y --no-install-recommends --no-install-suggests \
   libmxml-dev curl libxml2-dev libcunit1-dev libjsoncpp-dev \
   build-essential libtext-template-perl subversion rpm librpm-dev libmagic-dev libglib2.0 libboost-regex-dev libboost-program-options-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,14 +31,21 @@ RUN gem install licensee -v 9.10.1 --no-rdoc --no-ri
 WORKDIR /opt
 RUN git clone https://github.com/fossology/fossology.git
 
+RUN apt-get update && apt-get install -y --no-install-recommends --no-install-suggests \
+  libmxml-dev curl libxml2-dev libcunit1-dev libjsoncpp-dev \
+  build-essential libtext-template-perl subversion rpm librpm-dev libmagic-dev libglib2.0 libboost-regex-dev libboost-program-options-dev
+
 WORKDIR /opt/fossology/src/nomos/agent
 RUN make -f Makefile.sa
+RUN echo $(./nomossa -V)
 
+# NOTE: must build copyright before Monk to cause libfossology to be built
 WORKDIR /opt/fossology/src/copyright/agent
 RUN make
 
 WORKDIR /opt/fossology/src/monk/agent
 RUN make
+RUN echo $(./monk -V)
 
 ENV FOSSOLOGY_HOME=/opt/fossology/src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,16 @@ RUN git clone https://github.com/fossology/fossology.git
 
 WORKDIR /opt/fossology/src/nomos/agent
 RUN make -f Makefile.sa
-ENV FOSSOLOGY_HOME=/opt/fossology/src/nomos/agent
 
+WORKDIR /opt/fossology/src/copyright/agent
+RUN make
+
+WORKDIR /opt/fossology/src/monk/agent
+RUN make
+
+ENV FOSSOLOGY_HOME=/opt/fossology/src
+
+# Crawler config
 ENV CRAWLER_DEADLETTER_PROVIDER=cd(azblob)
 ENV CRAWLER_NAME=cdcrawlerprod
 ENV CRAWLER_QUEUE_PREFIX=cdcrawlerprod

--- a/config/cdConfig.js
+++ b/config/cdConfig.js
@@ -41,7 +41,7 @@ module.exports = {
     component: {},
     crate: { githubToken },
     fossology: {
-      installDir: config.get('FOSSOLOGY_HOME')
+      installDir: config.get('FOSSOLOGY_HOME') || '/mnt/c/git/fo/fossology/src/'
     },
     gem: { githubToken },
     licensee: {},

--- a/lib/baseHandler.js
+++ b/lib/baseHandler.js
@@ -86,6 +86,19 @@ class BaseHandler {
     })
   }
 
+  // Helper to take merge multiple semvers into one. This is useful where one handler is made up of
+  // multiple tools. The handler's version can be the sum of its composite tools versions
+  static _aggregateVersions(versions, errorRoot, base = '0.0.0') {
+    return versions
+      .reduce((result, version) => {
+        const parts = version.split('.')
+        if (parts.length !== 3 || parts.some(part => isNaN(+part))) throw new Error(`${errorRoot}: ${version}`)
+        for (let i = 0; i < 3; i++) result[i] += +parts[i]
+        return result
+      }, base.split('.').map(n => +n))
+      .join('.')
+  }
+
   get tmpOptions() {
     const tmpBase = this.options.tempLocation || (process.platform === 'win32' ? 'c:/temp/' : '/tmp/')
     return {

--- a/lib/baseHandler.js
+++ b/lib/baseHandler.js
@@ -13,7 +13,6 @@ const fs = require('fs')
 const path = require('path')
 const glob = require('fast-glob')
 const shajs = require('sha.js')
-const { pick } = require('lodash')
 
 tmp.setGracefulCleanup()
 const tmpOptions = {

--- a/providers/process/fossology.js
+++ b/providers/process/fossology.js
@@ -45,7 +45,7 @@ class FossologyProcessor extends BaseHandler {
       exec(
         `cd ${this.options.installDir}/nomos/agent && ./nomossa -ld ${request.document.location} ${parameters}`,
         { maxBuffer: 5000 * 1024 },
-        (error, stdout, stderr) => {
+        (error, stdout) => {
           if (error) {
             request.markDead('Error', error ? error.message : 'FOSSology run failed')
             return reject(error)

--- a/providers/process/fossology.js
+++ b/providers/process/fossology.js
@@ -7,6 +7,7 @@ const path = require('path')
 const { promisify } = require('util')
 const du = require('du')
 const bufferReplace = require('buffer-replace')
+const getFiles = promisify(require('node-dir').files)
 
 let _toolVersion
 let _nomosVersion
@@ -48,25 +49,80 @@ class FossologyProcessor extends BaseHandler {
   }
 
   async _runNomos(request) {
+    const version = await this._nomosVersion
     return new Promise((resolve, reject) => {
       // TODO add correct parameters and command line here
       const parameters = ['-ld', request.document.location].join(' ')
-      exec(`cd ${this.options.installDir} && ./nomossa ${parameters}`, { maxBuffer: 5000 * 1024 }, (error, stdout) => {
+      exec(
+        `cd ${this.options.installDir}/nomos/agent && ./nomossa ${parameters}`,
+        { maxBuffer: 5000 * 1024 },
+        (error, stdout, stderr) => {
+          if (error) {
+            request.markDead('Error', error ? error.message : 'FOSSology run failed')
+            return reject(error)
+          }
+          const output = {
+            contentType: 'text/plain',
+            content: bufferReplace(new Buffer(stdout), request.document.location + '/', '').toString()
+          }
+          const nomosOutput = { version, parameters, output }
+          resolve(nomosOutput)
+        }
+      )
+    })
+  }
+
+  async _visitFiles(files, runner) {
+    const results = []
+    for (const file of files) {
+      if (file) {
+        try {
+          const output = await runner(path)
+          if (output) results.push({ path: file, output: JSON.parse(output) })
+        } catch (error) {
+          this.logger.error(error)
+        }
+      }
+    }
+    return { output: { contentType: 'application/json', content: results } }
+  }
+
+  async _runCopyrights(request, files) {
+    const result = await this._visitFiles(files, path => this._runCopyright(request, path))
+    result.version = await this._copyrightVersion
+    return result
+  }
+
+  _runCopyright(request, file) {
+    return new Promise((resolve, reject) => {
+      const parameters = ['--files', file, '-J'].join(' ')
+      exec(`cd ${this.options.installDir}/copyright/agent && ./copyright ${parameters}`, (error, stdout) => {
         if (error) {
-          request.markDead('Error', error ? error.message : 'FOSSology run failed')
+          request.markDead('Error', error ? error.message : 'FOSSology copyright run failed')
           return reject(error)
         }
-        let buffer = new Buffer(stdout)
-        buffer = bufferReplace(buffer, request.document.location + '/', '')
-        const nomosOutput = {
-          version: this.nomosVersion,
-          parameters: parameters,
-          output: {
-            contentType: 'text/plain',
-            content: buffer.toString()
-          }
+        resolve(stdout)
+      })
+    })
+  }
+
+  async _runMonkOnFiles(request, files) {
+    const result = await this._visitFiles(files, path => this._runMonk(request, path))
+    result.version = await this._monkVersion
+    return result
+  }
+
+  _runMonk(request, file) {
+    // TODO figure out where to get a license file. May have to be created at build time
+    const licenseFile = ''
+    return new Promise((resolve, reject) => {
+      const parameters = ['-k', licenseFile, '-J', file].join(' ')
+      exec(`cd ${this.options.installDir}/monk/agent && ./monk ${parameters}`, (error, stdout) => {
+        if (error) {
+          request.markDead('Error', error ? error.message : 'FOSSology monk run failed')
+          return reject(error)
         }
-        resolve(nomosOutput)
+        resolve(stdout)
       })
     })
   }
@@ -89,33 +145,68 @@ class FossologyProcessor extends BaseHandler {
   }
 
   async _detectVersion() {
-    if (_toolVersion) return _toolVersion
-    return (_toolVersion = await this._detectNomosVersion())
+    if (this._versionPromise) return this._versionPromise
+    try {
+      // base is used to account for any high level changes in the way the FOSSology tools are run or configured
+      const base = '0.0.0'
+      this._nomosVersion = await this._detectNomosVersion()
+      this._copyrightVersion = await this._detectCopyrightVersion()
+      this._monkVersion = await this._detectMonkVersion()
+      return BaseHandler._aggregateVersions(
+        [this._nomosVersion, this._copyrightVersion, this._monkVersion],
+        'FOSSology tool version misformatted',
+        base
+      )
+    } catch (error) {
+      this.logger.log(`Could not find FOSSology tool version: ${error.message}`)
+      return null
+    }
   }
 
   _detectNomosVersion() {
     if (_nomosVersion !== undefined) return _nomosVersion
-    return new Promise(resolve => {
-      exec(`cd ${this.options.installDir} && ./nomossa -V`, (error, stdout) => {
-        if (error) {
-          // TODO log here
-          _nomosVersion = null
-          return resolve(null)
-        }
-        _nomosVersion = stdout.replace('nomos build version:', '').trim()
-        _nomosVersion = _nomosVersion.replace(/-.*/, '').trim()
-        resolve(_nomosVersion)
+    return new Promise((resolve, reject) => {
+      exec(`cd ${this.options.installDir}/nomos/agent && ./nomossa -V`, (error, stdout) => {
+        if (error) return reject(error)
+        const rawVersion = stdout.replace('nomos build version:', '').trim()
+        resolve(rawVersion.replace(/-.*/, '').trim())
       })
     })
   }
 
+  _detectMonkVersion() {
+    return new Promise((resolve, reject) => {
+      exec(`cd ${this.options.installDir}/monk/agent && ./monk -V`, (error, stdout) => {
+        if (error) return reject(error)
+        const rawVersion = stdout.replace('monk version', '').trim()
+        resolve(rawVersion.replace(/-.*/, '').trim())
+      })
+    })
+  }
+
+  // TODO see how copyright outputs its version and format accordingly. The code appears to not have
+  // a means of getting a version. So, for now, use 0.0.0 to simulate using the same version as
+  // nomos. That will be taken as the overall version of the FOSSology support as they are
+  // built from the same tree at the same time.
+  _detectCopyrightVersion() {
+    return new Promise(resolve => {
+      resolve('0.0.0')
+      // exec(`cd ${this.options.installDir}/copyright/agent && ./copyright -V`, (error, stdout) => {
+      //   if (error) return reject(null)
+      //   resolve('0.0.0')
+      // })
+    })
+  }
+
   async _createDocument(request) {
-    //const files = await getFiles(request.document.location)
+    const files = await getFiles(request.document.location)
     const nomosOutput = await this._runNomos(request)
-    //const copyrightOutput = await this._runCopyright(request, files)
-    //const monkOutput = await this._runMonk(request, files)
+    const copyrightOutput = await this._runCopyrights(request, files)
+    const monkOutput = await this._runMonk(request, files)
     request.document = { _metadata: request.document._metadata }
     if (nomosOutput) request.document.nomos = nomosOutput
+    if (copyrightOutput) request.document.copyright = copyrightOutput
+    if (monkOutput) request.document.monk = monkOutput
   }
 }
 

--- a/providers/process/fossology.js
+++ b/providers/process/fossology.js
@@ -87,13 +87,13 @@ class FossologyProcessor extends BaseHandler {
     return { output: { contentType: 'application/json', content: results } }
   }
 
-  async _runCopyrights(request, files) {
-    const result = await this._visitFiles(files, path => this._runCopyright(request, path))
+  async _runCopyright(request, files) {
+    const result = await this._visitFiles(files, path => this._runCopyrightOnFile(request, path))
     result.version = await this._copyrightVersion
     return result
   }
 
-  _runCopyright(request, file) {
+  _runCopyrightOnFile(request, file) {
     return new Promise((resolve, reject) => {
       const parameters = ['--files', file, '-J'].join(' ')
       exec(`cd ${this.options.installDir}/copyright/agent && ./copyright ${parameters}`, (error, stdout) => {
@@ -201,7 +201,7 @@ class FossologyProcessor extends BaseHandler {
   async _createDocument(request) {
     const files = await getFiles(request.document.location)
     const nomosOutput = await this._runNomos(request)
-    const copyrightOutput = await this._runCopyrights(request, files)
+    const copyrightOutput = await this._runCopyright(request, files)
     const monkOutput = await this._runMonk(request, files)
     request.document = { _metadata: request.document._metadata }
     if (nomosOutput) request.document.nomos = nomosOutput

--- a/providers/process/licensee.js
+++ b/providers/process/licensee.js
@@ -29,7 +29,7 @@ class LicenseeProcessor extends BaseHandler {
   }
 
   async handle(request) {
-    if (!(await this._versionPromise)) return request.markSkip('Licensee not found')
+    if (!(await this._versionPromise)) return request.markSkip('Licensee not properly configured')
     const { spec } = super._process(request)
     this.addBasicToolLinks(request, spec)
     await this._createDocument(request)
@@ -50,9 +50,9 @@ class LicenseeProcessor extends BaseHandler {
   async _run(request) {
     const parameters = ['--json', '--no-readme']
     const root = request.document.location
-    const paths = [root, ...(await promisify(dir.subdirs)(root))].map(path =>
-      path.slice(root.length).replace(/^[\/\\]+/g, '')
-    )
+    const paths = [root, ...(await promisify(dir.subdirs)(root))]
+      .map(path => path.slice(root.length).replace(/^[\/\\]+/g, ''))
+      .filter(path => path !== '.git' && !path.includes('.git/'))
     const results = await Promise.all(paths.map(throat(10, path => this._runOnFolder(path, root, parameters))))
     const licenses = uniqBy(flatten(results.map(result => result.licenses)), 'spdx_id')
     const matched_files = flatten(results.map(result => result.matched_files))

--- a/providers/process/scancode.js
+++ b/providers/process/scancode.js
@@ -129,7 +129,7 @@ class ScanCodeProcessor extends BaseHandler {
 
   _detectVersion() {
     if (this._versionPromise) return this._versionPromise
-    this._versionPromise = new Promise((resolve, reject) => {
+    this._versionPromise = new Promise(resolve => {
       exec(`cd ${this.options.installDir} && .${path.sep}scancode --version`, 1024, (error, stdout) => {
         if (error) this.logger.log(`Could not detect version of ScanCode: ${error.message}`)
         this._toolVersion = error ? null : stdout.replace('ScanCode version ', '').trim()

--- a/test/unit/lib/baseHandler.js
+++ b/test/unit/lib/baseHandler.js
@@ -104,6 +104,41 @@ describe('BaseHandler filesystem integration', () => {
   })
 })
 
+describe('BaseHandler util functions', () => {
+  it('version aggregation with one version', () => {
+    const result = BaseHandler._aggregateVersions(['1.2.3'], 'should not happen')
+    expect(result).to.equal('1.2.3')
+  })
+
+  it('version aggregation with multiple versions', () => {
+    const result = BaseHandler._aggregateVersions(['1.2.3', '2.3.4'], 'should not happen')
+    expect(result).to.equal('3.5.7')
+  })
+
+  it('version aggregation with base version', () => {
+    const result = BaseHandler._aggregateVersions(['1.2.3', '2.3.4'], 'should not happen', '1.1.1')
+    expect(result).to.equal('4.6.8')
+  })
+
+  it('version aggregation should fail with long versions', () => {
+    try {
+      BaseHandler._aggregateVersions(['1.2.3', '2.3.4.5'], 'should not happen')
+      expect(false).to.be.true
+    } catch (error) {
+      expect(error.message.includes('should not happen')).to.be.true
+    }
+  })
+
+  it('version aggregation should fail with non-numeric versions', () => {
+    try {
+      BaseHandler._aggregateVersions(['1.2.3', '2.3.b34'], 'should not happen')
+      expect(false).to.be.true
+    } catch (error) {
+      expect(error.message.includes('should not happen')).to.be.true
+    }
+  })
+})
+
 function validateInterestingFile(name, list, checkContent = false) {
   const attachment = `${path.basename(name)} attachment`
   const token = BaseHandler.computeToken(attachment)

--- a/test/unit/providers/processors/scancodeTests.js
+++ b/test/unit/providers/processors/scancodeTests.js
@@ -6,7 +6,6 @@ const expect = chai.expect
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const sandbox = sinon.createSandbox()
-const fs = require('fs')
 const { request } = require('ghcrawler')
 const BaseHandler = require('../../../../lib/baseHandler')
 
@@ -16,21 +15,18 @@ describe('ScanCode process', () => {
   it('should handle gems', async () => {
     const { request, processor } = setup('2.9.8/gem.json')
     await processor.handle(request)
-    const { document } = request
     expect(BaseHandler.attachFiles.args[0][1]).to.have.members([])
   })
 
   it('should handle simple npms', async () => {
     const { request, processor } = setup('2.9.8/npm-basic.json')
     await processor.handle(request)
-    const { document } = request
     expect(BaseHandler.attachFiles.args[0][1]).to.have.members(['package/package.json'])
   })
 
   it('should handle large npms', async () => {
     const { request, processor } = setup('2.9.8/npm-large.json')
     await processor.handle(request)
-    const { document } = request
     expect(BaseHandler.attachFiles.args[0][1]).to.have.members(['package/package.json'])
   })
 
@@ -45,7 +41,6 @@ describe('ScanCode process', () => {
     const processStub = {
       exec: (command, bufferLength, callback) => {
         if (command.includes('version')) return callback(resultBox.versionError, resultBox.versionResult)
-        const path = command.split(' ').slice(-1)
         callback(resultBox.error)
       }
     }


### PR DESCRIPTION
fixes #150 

Monk is very much like the copyright agent so do the same thing.

Some remaining points to consider
* need to generate and store the license database. likely in the docker build. Not really sure where all the data comes from.
* proposed implementation here runs monk once for each file. That causes the license DB to get loaded once per file. Likely a lot of overhead. Monk can take a list of files. Little unclear what the output looks like (JSON one entry per line with no info on about which file?). May be worth looking at running with more than one file at a time

Note that this depends on #228 