### PR TITLE
update scancode to 3.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends --no-install-su
 
 # Scancode
 RUN curl -sL https://github.com/nexB/scancode-toolkit/releases/download/v3.0.2/scancode-toolkit-3.0.2.tar.bz2 | tar -C /opt -jx \
-  && /opt/scancode-toolkit-3.0.3/scancode --reindex-licenses \
+  && /opt/scancode-toolkit-3.0.2/scancode --reindex-licenses \
   && /opt/scancode-toolkit-3.0.2/scancode --version
 ENV SCANCODE_HOME=/opt/scancode-toolkit-3.0.2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends --no-install-su
   gem install bundler --no-rdoc --no-ri
 
 # Scancode
-RUN curl -sL https://github.com/nexB/scancode-toolkit/archive/v2.9.8.tar.gz | tar -C /opt -zx \
-  && /opt/scancode-toolkit-2.9.8/scancode --reindex-licenses \
-  && /opt/scancode-toolkit-2.9.8/scancode --version
-ENV SCANCODE_HOME=/opt/scancode-toolkit-2.9.8
+RUN curl -sL https://github.com/nexB/scancode-toolkit/releases/download/v3.0.0/scancode-toolkit-3.0.0.tar.bz2 | tar -C /opt -jx \
+  && /opt/scancode-toolkit-3.0.0/scancode --reindex-licenses \
+  && /opt/scancode-toolkit-3.0.0/scancode --version
+ENV SCANCODE_HOME=/opt/scancode-toolkit-3.0.0
 
 # Licensee
 RUN gem install licensee -v 9.10.1 --no-rdoc --no-ri

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends --no-install-su
   gem install bundler --no-rdoc --no-ri
 
 # Scancode
-RUN curl -sL https://github.com/nexB/scancode-toolkit/releases/download/v3.0.0/scancode-toolkit-3.0.0.tar.bz2 | tar -C /opt -jx \
-  && /opt/scancode-toolkit-3.0.0/scancode --reindex-licenses \
-  && /opt/scancode-toolkit-3.0.0/scancode --version
-ENV SCANCODE_HOME=/opt/scancode-toolkit-3.0.0
+RUN curl -sL https://github.com/nexB/scancode-toolkit/releases/download/v3.0.2/scancode-toolkit-3.0.2.tar.bz2 | tar -C /opt -jx \
+  && /opt/scancode-toolkit-3.0.3/scancode --reindex-licenses \
+  && /opt/scancode-toolkit-3.0.2/scancode --version
+ENV SCANCODE_HOME=/opt/scancode-toolkit-3.0.2
 
 # Licensee
 RUN gem install licensee -v 9.10.1 --no-rdoc --no-ri

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends --no-install-su
   gem install bundler --no-rdoc --no-ri
 
 # Scancode
-RUN curl -sL https://github.com/nexB/scancode-toolkit/releases/download/v2.9.2/scancode-toolkit-2.9.2.tar.bz2 | tar -C /opt -jx \
-  && /opt/scancode-toolkit-2.9.2/scancode --reindex-licenses \
-  && /opt/scancode-toolkit-2.9.2/scancode --version
-ENV SCANCODE_HOME=/opt/scancode-toolkit-2.9.2
+RUN curl -sL https://github.com/nexB/scancode-toolkit/archive/v2.9.8.tar.gz | tar -C /opt -zx \
+  && /opt/scancode-toolkit-2.9.8/scancode --reindex-licenses \
+  && /opt/scancode-toolkit-2.9.8/scancode --version
+ENV SCANCODE_HOME=/opt/scancode-toolkit-2.9.8
 
 # Licensee
 RUN gem install licensee -v 9.10.1 --no-rdoc --no-ri

--- a/config/cdConfig.js
+++ b/config/cdConfig.js
@@ -58,6 +58,8 @@ module.exports = {
         '--copyright',
         '--license',
         '--info',
+        '--license-text',
+        '--is-license-text',
         '--package',
         '--license-diag',
         '--only-findings',

--- a/config/cdConfig.js
+++ b/config/cdConfig.js
@@ -62,13 +62,14 @@ module.exports = {
         '--is-license-text',
         '--package',
         '--license-diag',
+        ' --strip-root',
         '--email',
         '--url',
         '--license-clarity-score',
         '--classify',
         '--generated',
         '--summary',
-        '--summary-key-files',
+        '--summary-key-files'
         // '--quiet'
       ],
       timeout: 1000,

--- a/config/cdConfig.js
+++ b/config/cdConfig.js
@@ -53,7 +53,7 @@ module.exports = {
     pod: { githubToken },
     pypi: { githubToken },
     scancode: {
-      installDir: config.get('SCANCODE_HOME') || 'C:\\installs\\scancode-toolkit-2.9.2',
+      installDir: config.get('SCANCODE_HOME') || 'C:\\installs\\scancode-toolkit-3.0.2',
       options: [
         '--copyright',
         '--license',
@@ -62,8 +62,13 @@ module.exports = {
         '--is-license-text',
         '--package',
         '--license-diag',
-        '--only-findings',
-        ' --strip-root'
+        '--email',
+        '--url',
+        '--license-clarity-score',
+        '--classify',
+        '--generated',
+        '--summary',
+        '--summary-key-files',
         // '--quiet'
       ],
       timeout: 1000,

--- a/providers/process/scancode.js
+++ b/providers/process/scancode.js
@@ -68,26 +68,22 @@ class ScanCodeProcessor extends AbstractProcessor {
     const output = JSON.parse(fs.readFileSync(outputFile))
     // Pick files that are potentially whole licenses. We can be reasonably agressive here
     // and the summarizers etc will further refine what makes it into the final definitions
-    // TODO add other criteria here.
-    // TODO commenting out for now as `is_license_text` casts too broad a net (even iwth the scoring filter.
-    // Need a better predicate. In the end it's ok in general as we use Licensee as well. Problem is that only
-    // finds files with a single license. Was hoping that ScanCode could file a gap there.
-    // const files = output.files
-    //   .filter(file => file.licenses.some(license => license.score >= 50 && license.matched_rule.is_license_text))
-    //   .map(file => file.path)
+    const licenses = output.files.filter(file => file.is_license_text).map(file => file.path)
+    this.attachFiles(document, licenses, root)
 
     // Pick files that represent whole packages. We can be reasonably agressive here
     // and the summarizers etc will further refine what makes it into the final definitions
-    // TODO confirm with @pobmredanne that we need to reverse engineer this and that this is the correct way.
-    // Seems to work for NPM but need more examples.
     const packages = output.files.reduce((result, file) => {
       file.packages.forEach(entry => {
+        // in this case the manifest_path contains a subpath pointing to the corresponding file
         if (file.type === 'directory' && entry.manifest_path)
           result.push(`${file.path ? file.path + '/' : ''}${entry.manifest_path}`)
+        else
+          result.push(file.path)
       })
       return result
     }, [])
-    return this.attachFiles(document, packages, root)
+    this.attachFiles(document, packages, root)
   }
 
   // Workaround until https://github.com/nexB/scancode-toolkit/issues/983 is resolved

--- a/providers/process/scancode.js
+++ b/providers/process/scancode.js
@@ -61,10 +61,8 @@ class ScanCodeProcessor extends AbstractProcessor {
       }
     }
   }
+
   _attachInterestingFiles(document, outputFile, root) {
-    // TODO for each file, if we think its interesting, attach it. The interesting files of interest are things like
-    // package metadata or files found to BE full license texts. Need ScanCode to have a better way of detecting
-    // the latter.
     const output = JSON.parse(fs.readFileSync(outputFile))
     // Pick files that are potentially whole licenses. We can be reasonably agressive here
     // and the summarizers etc will further refine what makes it into the final definitions
@@ -78,8 +76,7 @@ class ScanCodeProcessor extends AbstractProcessor {
         // in this case the manifest_path contains a subpath pointing to the corresponding file
         if (file.type === 'directory' && entry.manifest_path)
           result.push(`${file.path ? file.path + '/' : ''}${entry.manifest_path}`)
-        else
-          result.push(file.path)
+        else result.push(file.path)
       })
       return result
     }, [])

--- a/test/unit/providers/process/scancodeTests.js
+++ b/test/unit/providers/process/scancodeTests.js
@@ -7,6 +7,7 @@ const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const sandbox = sinon.createSandbox()
 const { request } = require('ghcrawler')
+const { flatten } = require('lodash')
 
 let Handler
 
@@ -52,19 +53,19 @@ describe('ScanCode process', () => {
     const { request, processor } = setup('2.9.8/gem.json')
     await processor.handle(request)
     expect(request.document._metadata.toolVersion).to.equal('1.2.0')
-    expect(processor.attachFiles.args[0][1]).to.have.members([])
+    expect(flatten(processor.attachFiles.args.map(x => x[1]))).to.have.members([])
   })
 
   it('should handle simple npms', async () => {
     const { request, processor } = setup('2.9.8/npm-basic.json')
     await processor.handle(request)
-    expect(processor.attachFiles.args[0][1]).to.have.members(['package/package.json'])
+    expect(flatten(processor.attachFiles.args.map(x => x[1]))).to.have.members(['package/package.json'])
   })
 
   it('should handle large npms', async () => {
     const { request, processor } = setup('2.9.8/npm-large.json')
     await processor.handle(request)
-    expect(processor.attachFiles.args[0][1]).to.have.members(['package/package.json'])
+    expect(flatten(processor.attachFiles.args.map(x => x[1]))).to.have.members(['package/package.json'])
   })
 
   it('should skip if ScanCode not found', async () => {


### PR DESCRIPTION
This PR updates ScanCode to v3.0.2, updates the command line options and refines the collection of "interesting files" in particular:
- ensure that package manifest files are picked too (and not only package data at the directory level)
- collect whole license text files with the new `is_license_text` flag available at the files level

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com> 