### PR TITLE
use shallow clone for git fetch

### DIFF
--- a/providers/fetch/gitCloner.js
+++ b/providers/fetch/gitCloner.js
@@ -41,7 +41,7 @@ class GitCloner extends AbstractFetch {
   _cloneRepo(sourceUrl, dirName, specName, commit) {
     return new Promise((resolve, reject) => {
       exec(
-        `cd ${dirName} && git clone ${sourceUrl} --quiet && cd ${specName} && git reset --hard ${commit} --quiet && git count-objects -v`,
+        `cd ${dirName} && git clone --depth 1 --quiet ${sourceUrl} && cd ${specName} && git reset --hard ${commit} --quiet && git count-objects -v`,
         (error, stdout) => (error ? reject(error) : resolve(this._getRepoSize(stdout)))
       )
     })


### PR DESCRIPTION
Somewhere we found doc that said that shallow clone did not work on GitHub but I found that it does! And `git show` still works. We should be able to speed up quite a bit. In particular, not the size difference 27.52 MiB for full clone vs 578.08 KiB for shallwo

```
C:\temp>git clone --depth 1 https://github.com/jquery/jquery.git
Cloning into 'jquery'...
remote: Enumerating objects: 323, done.
remote: Counting objects: 100% (323/323), done.
remote: Compressing objects: 100% (307/307), done.
remote: Total 323 (delta 12), reused 146 (delta 1), pack-reused 0
Receiving objects: 100% (323/323), 578.08 KiB | 8.50 MiB/s, done.
Resolving deltas: 100% (12/12), done.

C:\temp>git clone https://github.com/jquery/jquery.git jt
Cloning into 'jt'...
remote: Enumerating objects: 1, done.
remote: Counting objects: 100% (1/1), done.
remote: Total 42994 (delta 0), reused 0 (delta 0), pack-reused 42993R
Receiving objects: 100% (42994/42994), 27.52 MiB | 15.67 MiB/s, done.
Resolving deltas: 100% (30458/30458), done.

C:\temp>cd jquery
C:\temp\jquery>git show -s --format=%ci
2018-12-14 22:06:44 +0100

C:\temp\jquery>cd ..\jt
C:\temp\jt>git show -s --format=%ci
2018-12-14 22:06:44 +0100
```