### PR TITLE
normalize git revisions after clone

### DIFF
--- a/providers/fetch/gitCloner.js
+++ b/providers/fetch/gitCloner.js
@@ -21,6 +21,8 @@ class GitCloner extends AbstractFetch {
     const dir = this.createTempDir(request)
     const repoSize = await this._cloneRepo(sourceSpec.toUrl(), dir.name, spec.name, options.version)
     request.addMeta({ gitSize: repoSize })
+    spec.revision = await this._getRevision(dir.name, spec.name)
+    request.url = spec.toUrl()
     const releaseDate = await this._getDate(dir.name, spec.name)
     await this._deleteGitDatabase(dir.name, spec.name)
     request.contentOrigin = 'origin'
@@ -39,9 +41,10 @@ class GitCloner extends AbstractFetch {
   }
 
   _cloneRepo(sourceUrl, dirName, specName, commit) {
+    const reset = commit ? `&& git reset --hard ${commit} --quiet` : ''
     return new Promise((resolve, reject) => {
       exec(
-        `cd ${dirName} && git clone ${sourceUrl} --quiet && cd ${specName} && git reset --hard ${commit} --quiet && git count-objects -v`,
+        `cd ${dirName} && git clone ${sourceUrl} --quiet && cd ${specName} ${reset} && git count-objects -v`,
         (error, stdout) => (error ? reject(error) : resolve(this._getRepoSize(stdout)))
       )
     })
@@ -51,6 +54,19 @@ class GitCloner extends AbstractFetch {
     return new Promise((resolve, reject) => {
       exec(`cd ${dirName}/${specName} && git show -s --format=%ci`, (error, stdout) =>
         error ? reject(error) : resolve(new Date(stdout.trim()))
+      )
+    })
+  }
+
+  /**
+   * We normalize the revision so that they are consistent in the harvested output
+   * this allows a shortened commit hash as input to be saved as a full commit hash
+   * this also allows git-like words like 'HEAD' and also tag names to be normalized
+   */
+  _getRevision(dirName, specName) {
+    return new Promise((resolve, reject) => {
+      exec(`cd ${dirName}/${specName} && git rev-parse HEAD`, (error, stdout) =>
+        error ? reject(error) : resolve(stdout.trim())
       )
     })
   }


### PR DESCRIPTION
   * We normalize the revision so that they are consistent in the harvested output
   * this allows a shortened commit hash as input to be saved as a full commit hash
   * this also allows git-like words like 'HEAD' and also tag names to be normalized