### PR TITLE
only post the _metadata part of the document to the service

### DIFF
--- a/providers/store/webhookDeltaStore.js
+++ b/providers/store/webhookDeltaStore.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 const request = require('request-promise-native')
+const { pick } = require('lodash')
 
 class WebhookDeltaStore {
   constructor(options) {
@@ -19,7 +20,7 @@ class WebhookDeltaStore {
       method: 'POST',
       uri,
       json: true,
-      body: document,
+      body: pick(document, '_metadata'),
       headers: {
         'x-crawler': this.options.token || 'secret'
       },


### PR DESCRIPTION
We only need the self link as the receiver is responsible for fetching the latest document anyways.

Some of the documents we have been posting have been > 5MB and causing issues