### PR TITLE
use smartgit to discoverFromGitHubTags (fixes #269)

### DIFF
--- a/lib/sourceDiscovery.js
+++ b/lib/sourceDiscovery.js
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
-const _ = require('lodash')
+const { uniq, uniqWith } = require('lodash')
 const ghrequestor = require('ghrequestor')
 const request = require('requestretry')
+const geit = require('geit')
 // TODO why not parse-github-repo-url (10x more downloads)
 const parseGitHubUrl = require('parse-github-url')
 const SourceSpec = require('./sourceSpec')
@@ -24,7 +25,7 @@ module.exports = async function searchForRevisions(version, candidateUrls, optio
   if (!candidateUrls || candidateUrls.length === 0) return null
 
   // TODO rationalize this and don't assume everything is coming from GitHub.
-  const resolved = resolveGitHubLocations(_.uniq(candidateUrls))
+  const resolved = resolveGitHubLocations(uniq(candidateUrls))
   for (let candidate of resolved) {
     const revisionInfo = await discoverRevision(version, candidate, options)
     if (revisionInfo) return revisionInfo
@@ -36,9 +37,9 @@ async function discoverRevision(version, candidate, options) {
   const provider = getProvider(candidate)
   switch (provider) {
     case 'github': {
-      const tag = await discoverFromGitHubTags(version, candidate, options)
-      if (!tag) return null
-      return tag ? new SourceSpec('git', 'github', candidate.owner, candidate.name, tag.revision) : null
+      const sha = await discoverFromGitHubTags(version, candidate, options)
+      if (!sha) return null
+      return new SourceSpec('git', 'github', candidate.owner, candidate.name, sha)
     }
     // TODO add more handlers here (e.g., gitlab, bitbucket, ...)
     default:
@@ -53,7 +54,7 @@ function resolveGitHubLocations(locations) {
       return parsedUrl && parsedUrl.owner && parsedUrl.name ? parsedUrl : null
     })
     .filter(e => e)
-  return _.uniqWith(result, (a, b) => a.owner === b.owner && a.name === b.name)
+  return uniqWith(result, (a, b) => a.owner === b.owner && a.name === b.name)
 }
 
 // TODO don't use this right now. Leaving here as a backup/record of doing ref based vs tag based lookup.
@@ -91,36 +92,17 @@ async function discoverFromGitHubRefs(version, candidate, options) {
   }
 }
 
-async function discoverFromGitHubTags(version, candidate, options) {
-  const headers = {
-    'User-Agent': 'clearlydefined/scanning'
-  }
-  const token = options.githubToken
-  if (token) headers.Authorization = 'token ' + token
-
-  const url = `https://api.github.com/repos/${encodeURIComponent(candidate.owner)}/${encodeURIComponent(
-    candidate.name
-  )}/tags`
-  try {
-    const tags = await ghrequestor.getAll(url, {
-      headers,
-      maxAttempts: 3,
-      retryDelay: 250,
-      retryStrategy: request.RetryStrategies.HTTPOrNetworkError,
-      tokenLowerBound: 10,
-      json: true
-    })
-    if (!tags) return null
-    for (let i = 0; i < tags.length; i++) {
-      const tag = tags[i]
-      if (tag.name === version || tag.name === `v${version}`) return { url: tag.commit.url, revision: tag.commit.sha }
-    }
-    console.log(`Failed to find GitHub tag for ${url}`)
-    return null
-  } catch (error) {
-    // TODO do better here
-    console.log(`Failed finding GitHub tag for ${url} ${error}`)
-  }
+async function discoverFromGitHubTags(version, candidate) {
+  const repo = geit(
+    `https://github.com/${encodeURIComponent(candidate.owner)}/${encodeURIComponent(candidate.name)}.git`
+  )
+  const refs = await repo.refs()
+  return (
+    refs[`refs/tags/${version}^{}`] ||
+    refs[`refs/tags/v${version}^{}`] ||
+    refs[`refs/tags/${version}`] ||
+    refs[`refs/tags/v${version}`]
+  )
 }
 
 function getProvider(location) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -216,6 +216,14 @@
       "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
       "dev": true
     },
+    "abstract-leveldown": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+      "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+      "requires": {
+        "xtend": "~4.0.0"
+      }
+    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -1470,6 +1478,14 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "deferred-leveldown": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
+      "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
+      "requires": {
+        "abstract-leveldown": "~2.6.0"
+      }
+    },
     "defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
@@ -1693,6 +1709,14 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
       "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+    },
+    "errno": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+      "requires": {
+        "prr": "~1.0.1"
+      }
     },
     "es5-ext": {
       "version": "0.10.47",
@@ -2362,8 +2386,18 @@
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-      "dev": true
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+    },
+    "geit": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/geit/-/geit-0.0.7.tgz",
+      "integrity": "sha1-wEBUslKL16WTTWGbr99s1JfuzCk=",
+      "requires": {
+        "levelup": "^1.3.1",
+        "memdown": "^1.1.1",
+        "pako": "^0.2.8",
+        "request": "^2.67.0"
+      }
     },
     "generate-function": {
       "version": "2.3.1",
@@ -2689,6 +2723,11 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
+    },
+    "immediate": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+      "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -3246,6 +3285,74 @@
         "invert-kv": "^1.0.0"
       }
     },
+    "level-codec": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
+      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
+    },
+    "level-errors": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
+      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
+      "requires": {
+        "errno": "~0.1.1"
+      }
+    },
+    "level-iterator-stream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+      "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "level-errors": "^1.0.3",
+        "readable-stream": "^1.0.33",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "levelup": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
+      "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
+      "requires": {
+        "deferred-leveldown": "~1.2.1",
+        "level-codec": "~7.0.0",
+        "level-errors": "~1.0.3",
+        "level-iterator-stream": "~1.3.0",
+        "prr": "~1.0.1",
+        "semver": "~5.4.1",
+        "xtend": "~4.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+        }
+      }
+    },
     "leven": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
@@ -3357,6 +3464,11 @@
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
+    "ltgt": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
+    },
     "make-dir": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -3376,6 +3488,29 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "memdown": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
+      "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
+      "requires": {
+        "abstract-leveldown": "~2.7.1",
+        "functional-red-black-tree": "^1.0.1",
+        "immediate": "^3.2.3",
+        "inherits": "~2.0.1",
+        "ltgt": "~2.2.0",
+        "safe-buffer": "~5.1.1"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+          "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+          "requires": {
+            "xtend": "~4.0.0"
+          }
+        }
+      }
     },
     "memory-cache": {
       "version": "0.1.6",
@@ -4859,6 +4994,11 @@
         "walk-back": "^1.1.0"
       }
     },
+    "pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+    },
     "parse-github-url": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
@@ -5048,6 +5188,11 @@
         "module-not-found-error": "^1.0.0",
         "resolve": "~1.8.1"
       }
+    },
+    "prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "psl": {
       "version": "1.1.29",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "du": "^0.1.0",
     "extend": "^3.0.1",
     "extract-zip": "^1.6.6",
+    "geit": "0.0.7",
     "ghcrawler": "github:microsoft/ghcrawler#jm/apicrawler",
     "ghrequestor": "^0.1.7",
     "lodash": "^4.17.5",

--- a/providers/process/npmExtract.js
+++ b/providers/process/npmExtract.js
@@ -15,7 +15,7 @@ class NpmExtract extends AbstractClearlyDefinedProcessor {
   }
 
   get toolVersion() {
-    return '1.1.3'
+    return '1.1.4'
   }
 
   canHandle(request) {

--- a/providers/process/nugetExtract.js
+++ b/providers/process/nugetExtract.js
@@ -69,7 +69,7 @@ class NuGetExtract extends AbstractClearlyDefinedProcessor {
   async _discoverSource(manifest, nuspec) {
     const manifestCandidates = this._discoverCandidateSourceLocations(manifest)
     const nuspecCandidates = this._discoverCandidateSourceLocations(get(nuspec, 'package.metadata'))
-    const candidates = [...manifestCandidates, ...nuspecCandidates]
+    const candidates = [...nuspecCandidates, ...manifestCandidates]
     return this.sourceFinder(manifest.version, candidates, {
       githubToken: this.options.githubToken
     })

--- a/test/unit/providers/process/nugetExtractTests.js
+++ b/test/unit/providers/process/nugetExtractTests.js
@@ -120,14 +120,14 @@ describe('nugetExtract source discovery', () => {
     expect(sourceLocation.name).to.eq('project')
   })
 
-  it('prioritizes manifest over nuspec', async () => {
+  it('prioritizes nuspec over manifest', async () => {
     const finder = sinon.stub().callsFake(sourceDiscovery())
     const extractor = extract({}, finder)
     const manifest = createManifest(null, null, 'http://license')
     const registry = createNuspec('http://repo')
     const sourceLocation = await extractor._discoverSource(manifest, registry)
     expect(sourceLocation.revision).to.eq('42')
-    expect(sourceLocation.name).to.eq('license')
+    expect(sourceLocation.name).to.eq('repo')
   })
 })
 


### PR DESCRIPTION
the url internally is
https://github.com/{owner}/{repo}.git/info/refs?service=git-upload-pack

- uses https://www.npmjs.com/package/geit to fetch refs instead gh apis
- will not rely on gh tokens this way