### PR TITLE
update getartifact for maven fetch

### DIFF
--- a/providers/fetch/mavencentralFetch.js
+++ b/providers/fetch/mavencentralFetch.js
@@ -68,7 +68,7 @@ class MavenFetch extends AbstractFetch {
   }
 
   _buildUrl(spec, extension = extensionMap.jar) {
-    const fullName = `${spec.namespace}/${spec.name}`.replace(/\./g, '/')
+    const fullName = `${spec.namespace.replace(/\./g, '/')}/${spec.name}`
     return `${providerMap[spec.provider]}${fullName}/${spec.revision}/${spec.name}-${spec.revision}${extension}`
   }
 

--- a/providers/fetch/mavencentralFetch.js
+++ b/providers/fetch/mavencentralFetch.js
@@ -16,12 +16,10 @@ const providerMap = {
   mavencentral: 'https://search.maven.org/remotecontent?filepath='
 }
 const extensionMap = {
-  sourcearchive: '-sources.jar',
+  sourcesJar: '-sources.jar',
   pom: '.pom',
   aar: '.aar',
-  bundle: '.jar',
-  jar: '.jar',
-  maven: '.jar'
+  jar: '.jar'
 }
 
 class MavenFetch extends AbstractFetch {
@@ -41,8 +39,8 @@ class MavenFetch extends AbstractFetch {
     if (!poms.length) return this.markSkip(request)
     const summary = this._mergePoms(poms)
     const artifact = this.createTempFile(request)
-    const code = await this._getArtifact(spec, artifact.name, spec.type, summary)
-    if (code === 404) return this.markSkip(request)
+    const artifactResult = await this._getArtifact(spec, artifact.name)
+    if (!artifactResult) return this.markSkip(request)
     const dir = this.createTempDir(request)
     await this.decompress(artifact.name, dir.name)
     const hashes = await this.computeHashes(artifact.name)
@@ -69,25 +67,26 @@ class MavenFetch extends AbstractFetch {
     return { location: dir.name, releaseDate, hashes, poms, summary }
   }
 
-  _buildUrl(spec, type, summary) {
-    const packaging = get(summary, 'packaging[0]')
-    const extension = packaging ? extensionMap[packaging] : extensionMap[type || spec.type]
-    if (!extension) throw new Error(`Unable to build URL. Packaging: ${packaging}; Type: ${type || spec.type}  `)
+  _buildUrl(spec, extension = extensionMap.jar) {
     const fullName = `${spec.namespace}/${spec.name}`.replace(/\./g, '/')
     return `${providerMap[spec.provider]}${fullName}/${spec.revision}/${spec.name}-${spec.revision}${extension}`
   }
 
-  _getArtifact(spec, destination, type, summary) {
-    const url = this._buildUrl(spec, type, summary)
-    return new Promise((resolve, reject) => {
-      nodeRequest
-        .get(url, (error, response) => {
-          if (error) return reject(error)
-          if (response.statusCode === 404) resolve(response.statusCode)
-          if (response.statusCode !== 200) reject(new Error(`${response.statusCode} ${response.statusMessage}`))
-        })
-        .pipe(fs.createWriteStream(destination).on('finish', () => resolve(null)))
-    })
+  async _getArtifact(spec, destination) {
+    const extensions = spec.type === 'sourcearchive' ? [extensionMap.sourcesJar] : [extensionMap.jar, extensionMap.aar]
+    for (let extension of extensions) {
+      const url = this._buildUrl(spec, extension)
+      const status = await new Promise(resolve => {
+        nodeRequest
+          .get(url, (error, response) => {
+            if (error) this.logger.error(error)
+            if (response.statusCode !== 200) return resolve(false)
+          })
+          .pipe(fs.createWriteStream(destination).on('finish', () => resolve(true)))
+      })
+      if (status) return true
+    }
+    return false
   }
 
   async _getPoms(spec, result = []) {
@@ -99,7 +98,7 @@ class MavenFetch extends AbstractFetch {
   }
 
   async _getPom(spec) {
-    const url = this._buildUrl(spec, 'pom')
+    const url = this._buildUrl(spec, extensionMap.pom)
     let content
     try {
       content = await requestPromise({ url, json: false })

--- a/test/unit/providers/fetch/mavencentralFetchTests.js
+++ b/test/unit/providers/fetch/mavencentralFetchTests.js
@@ -19,7 +19,7 @@ describe('Maven Central utility functions', () => {
       stub + 'g1/a1/1.2.3/a1-1.2.3-sources.jar'
     )
     expect(fetch._buildUrl(spec('maven', 'com.g1', 'a1.foo', '1.2.3'))).to.equal(
-      stub + 'com/g1/a1/foo/1.2.3/a1.foo-1.2.3.jar'
+      stub + 'com/g1/a1.foo/1.2.3/a1.foo-1.2.3.jar'
     )
     expect(fetch._buildUrl(spec('maven', 'g1', 'a1', '1.2.3'), '.jar')).to.equal(stub + 'g1/a1/1.2.3/a1-1.2.3.jar')
     expect(fetch._buildUrl(spec('maven', 'g1', 'a1', '1.2.3'), '.aar')).to.equal(stub + 'g1/a1/1.2.3/a1-1.2.3.aar')

--- a/test/unit/providers/fetch/mavencentralFetchTests.js
+++ b/test/unit/providers/fetch/mavencentralFetchTests.js
@@ -13,21 +13,16 @@ const stub = 'https://search.maven.org/remotecontent?filepath='
 describe('Maven Central utility functions', () => {
   it('builds URLs', () => {
     const fetch = MavenFetch({})
-    expect(fetch._buildUrl(spec('maven', 'g1', 'a1', '1.2.3'), 'pom')).to.equal(stub + 'g1/a1/1.2.3/a1-1.2.3.pom')
+    expect(fetch._buildUrl(spec('maven', 'g1', 'a1', '1.2.3'), '.pom')).to.equal(stub + 'g1/a1/1.2.3/a1-1.2.3.pom')
     expect(fetch._buildUrl(spec('maven', 'g1', 'a1', '1.2.3'))).to.equal(stub + 'g1/a1/1.2.3/a1-1.2.3.jar')
-    expect(fetch._buildUrl(spec('sourcearchive', 'g1', 'a1', '1.2.3'))).to.equal(
+    expect(fetch._buildUrl(spec('sourcearchive', 'g1', 'a1', '1.2.3'), '-sources.jar')).to.equal(
       stub + 'g1/a1/1.2.3/a1-1.2.3-sources.jar'
     )
     expect(fetch._buildUrl(spec('maven', 'com.g1', 'a1.foo', '1.2.3'))).to.equal(
       stub + 'com/g1/a1/foo/1.2.3/a1.foo-1.2.3.jar'
     )
-    expect(fetch._buildUrl(spec('maven', 'g1', 'a1', '1.2.3'), 'maven')).to.equal(stub + 'g1/a1/1.2.3/a1-1.2.3.jar')
-    expect(fetch._buildUrl(spec('maven', 'g1', 'a1', '1.2.3'), 'maven', { packaging: ['aar'] })).to.equal(
-      stub + 'g1/a1/1.2.3/a1-1.2.3.aar'
-    )
-    expect(fetch._buildUrl(spec('maven', 'g1', 'a1', '1.2.3'), 'maven', { packaging: ['bundle'] })).to.equal(
-      stub + 'g1/a1/1.2.3/a1-1.2.3.jar'
-    )
+    expect(fetch._buildUrl(spec('maven', 'g1', 'a1', '1.2.3'), '.jar')).to.equal(stub + 'g1/a1/1.2.3/a1-1.2.3.jar')
+    expect(fetch._buildUrl(spec('maven', 'g1', 'a1', '1.2.3'), '.aar')).to.equal(stub + 'g1/a1/1.2.3/a1-1.2.3.aar')
   })
 
   it('merges poms', () => {
@@ -130,10 +125,10 @@ describe('MavenCentral fetching', () => {
     }
     handler._getArtifact = () => {}
     try {
-      await handler.handle(new Request('test', 'cd:/maven/mavencentral/org.eclipse/error/3.3.0-v3344'))
-      expect(false).to.be.true
+      const result = await handler.handle(new Request('test', 'cd:/maven/mavencentral/org.eclipse/error/3.3.0-v3344'))
+      expect(result.outcome).to.eq('Missing  ')
     } catch (error) {
-      expect(error.message).to.be.equal('yikes')
+      expect(true).to.be.equal(false)
     }
   })
 


### PR DESCRIPTION
instead of trying to decuce the extension, and making _buildUrl be smart this proposal does the following

 - pass the desired extension to _buildUrl 
 - for type=sourcearchive always go for `-sources.jar`
 - for poms always do `.pom`
 - for maven artifacts try `.jar` and `.aar` in turn until you get a hit