### PR TITLE
move exec inputs to parameter lists from string manipulations

### DIFF
--- a/config/cdConfig.js
+++ b/config/cdConfig.js
@@ -62,7 +62,7 @@ module.exports = {
         '--is-license-text',
         '--package',
         '--license-diag',
-        ' --strip-root',
+        '--strip-root',
         '--email',
         '--url',
         '--license-clarity-score',

--- a/test/unit/providers/process/licenseeTests.js
+++ b/test/unit/providers/process/licenseeTests.js
@@ -54,10 +54,11 @@ describe('Licensee process', () => {
   beforeEach(function() {
     const resultBox = { error: null, versionResult: '1.2.0', versionError: null }
     const processStub = {
-      exec: (command, bufferLength, callback) => {
-        if (command.includes('version')) return callback(resultBox.versionError, resultBox.versionResult)
-        const path = command.split(' ').slice(-1)
-        callback(resultBox.error, fs.readFileSync(`${path}/output.json`))
+      execFile: (command, parameters, callbackOrOptions, callback) => {
+        if (parameters.includes('version'))
+          return callbackOrOptions(resultBox.versionError, { stdout: resultBox.versionResult })
+        const path = parameters.slice(-1)[0]
+        callback(resultBox.error, { stdout: fs.readFileSync(`${path}/output.json`).toString() })
       }
     }
     Handler = proxyquire('../../../../providers/process/licensee', { child_process: processStub })

--- a/test/unit/providers/process/scancodeTests.js
+++ b/test/unit/providers/process/scancodeTests.js
@@ -87,8 +87,9 @@ describe('ScanCode process', () => {
   beforeEach(function() {
     const resultBox = { error: null, versionResult: '1.2.0', versionError: null }
     const processStub = {
-      exec: (command, bufferLength, callback) => {
-        if (command.includes('version')) return callback(resultBox.versionError, resultBox.versionResult)
+      execFile: (command, parameters, callbackOrOptions, callback) => {
+        if (parameters.includes('--version'))
+          return callbackOrOptions(resultBox.versionError, { stdout: resultBox.versionResult })
         callback(resultBox.error)
       }
     }


### PR DESCRIPTION
we handle parameters and arguments as arrays of individual values instead of executing a string. This is to prevent malicious command injection, and also to help handle file/folder names that are not compatible with the shell.