### PR TITLE
adds config variable for using a different temporary directory for pr…

### DIFF
--- a/lib/baseHandler.js
+++ b/lib/baseHandler.js
@@ -6,6 +6,7 @@ const semver = require('semver')
 const EntitySpec = require('../lib/entitySpec')
 const fs = require('fs')
 const crypto = require('crypto')
+const config = require('painless-config')
 
 tmp.setGracefulCleanup()
 
@@ -20,10 +21,10 @@ class BaseHandler {
    * @param {Request} request
    */
   // eslint-disable-next-line no-unused-vars
-  handle(request) {}
+  handle(request) { }
 
   get tmpOptions() {
-    const tmpBase = this.options.tempLocation || (process.platform === 'win32' ? 'c:/temp/' : '/tmp/')
+    const tmpBase = config.get('TEMPDIR') || (process.platform === 'win32' ? 'c:/temp/' : '/tmp/')
     return {
       unsafeCleanup: true,
       template: tmpBase + 'cd-XXXXXX'


### PR DESCRIPTION
…ocessing scan results

This is a partial fix for https://github.com/clearlydefined/service/issues/841.

Currently, when the crawler runs a scan, clones a repo, etc., it temporarily stores the results within the container running the crawler. This works...but we are now seeing errors where the container is running out of memory with certain components. I believe this is the reason we are seeing partial harvests.

This change allows someone to configure a separate memory store (such as block storage), mount it to the container, and then use it for the temporary storage required by the crawler. If the block storage has sufficient memory, this should prevent these out of memory errors.

This can be deployed as is without any change to the infrastructure running the crawlers. It will default to using the local container memory for temporary storage. Once it is merged and deployed to the Azure dev environment, I will create a file share, mount it to the app service running the dev crawler, and then change the app service configuration to use the file share for temporary storage. I will verify that all is functioning as expected.

This change can then be deployed to production as is (without changes to infra), and it will not change the behavior of the production crawlers.

To use the new behavior with the production crawlers, we will need to make changes across three clouds (these don't have to be done simultaneously).

* Azure
* AWS
* Google

The Azure changes should be straightforward, I am working on finding contacts at AWS and Google to make the required config change for the crawlers running in their clouds. We should be able to make the infra changes at any time.

Signed-off-by: Nell Shamrell <nells@microsoft.com>