### PR TITLE
[WIP]: Build failed when creating docker image.

### DIFF
--- a/DevDockerfile
+++ b/DevDockerfile
@@ -10,10 +10,10 @@ ENV CRAWLER_BUILD_NUMBER=$BUILD_NUMBER
 # Ruby and Python Dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends --no-install-suggests curl bzip2 build-essential libssl-dev libreadline-dev zlib1g-dev cmake python3 python3-dev python3-pip xz-utils libxml2-dev libxslt1-dev libpopt0 && \
   rm -rf /var/lib/apt/lists/* && \
-  curl -L https://github.com/rbenv/ruby-build/archive/v20180822.tar.gz | tar -zxvf - -C /tmp/ && \
+  curl -L https://github.com/rbenv/ruby-build/archive/v20220426.tar.gz | tar -zxvf - -C /tmp/ && \
   cd /tmp/ruby-build-* && ./install.sh && cd / && \
-  ruby-build -v 2.5.1 /usr/local && rm -rfv /tmp/ruby-build-* && \
-  gem install bundler --no-rdoc --no-ri
+  ruby-build -v 3.1.2 /usr/local && rm -rfv /tmp/ruby-build-* && \
+  gem install bundler --no-document
 
 # Scancode
 RUN pip3 install --upgrade pip setuptools wheel && \
@@ -24,11 +24,7 @@ RUN pip3 install --upgrade pip setuptools wheel && \
 ENV SCANCODE_HOME=/usr/local/bin
 
 # Licensee
-# The latest version of nokogiri (1.13.1) is not working well
-# With this base image, so we pin to the previous version
-# of nokogiri for use with licensee
-RUN gem install nokogiri:1.12.5 --no-rdoc --no-ri && \
-  gem install licensee:9.12.0 --no-rdoc --no-ri
+RUN gem install licensee:9.12.0 --no-document
 
 # REUSE
 RUN pip3 install setuptools

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,10 @@ ENV CRAWLER_BUILD_NUMBER=$BUILD_NUMBER
 # Ruby and Python Dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends --no-install-suggests curl bzip2 build-essential libssl-dev libreadline-dev zlib1g-dev cmake python3 python3-dev python3-pip && \
   rm -rf /var/lib/apt/lists/* && \
-  curl -L https://github.com/rbenv/ruby-build/archive/v20180822.tar.gz | tar -zxvf - -C /tmp/ && \
+  curl -L https://github.com/rbenv/ruby-build/archive/v20220426.tar.gz | tar -zxvf - -C /tmp/ && \
   cd /tmp/ruby-build-* && ./install.sh && cd / && \
-  ruby-build -v 2.5.1 /usr/local && rm -rfv /tmp/ruby-build-* && \
-  gem install bundler --no-rdoc --no-ri
+  ruby-build -v 3.1.2 /usr/local && rm -rfv /tmp/ruby-build-* && \
+  gem install bundler --no-document
 
 # Scancode
 RUN pip3 install --upgrade pip setuptools wheel && \
@@ -30,11 +30,7 @@ RUN pip3 install --upgrade pip setuptools wheel && \
 ENV SCANCODE_HOME=/usr/local/bin
 
 # Licensee
-# The latest version of nokogiri (1.13.1) is not working well
-# With this base image, so we pin to the previous version
-# of nokogiri for use with licensee
-RUN gem install nokogiri:1.12.5 --no-rdoc --no-ri && \
-  gem install licensee:9.12.0 --no-rdoc --no-ri
+RUN gem install licensee:9.12.0 --no-document
 
 # REUSE
 RUN pip3 install setuptools


### PR DESCRIPTION
Background:

[This](https://dev.azure.com/clearlydefined/ClearlyDefined/_build/results?buildId=8625&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=457762fb-7913-5721-db09-27cc274cbeba&l=4230) build failed because of the following error.

```
ERROR:  Error installing licensee:
	The last version of faraday (< 3, >= 1) to support your Ruby & RubyGems was 1.10.0. Try installing it with `gem install faraday -v 1.10.0` and then running the current command again
	faraday requires Ruby version >= 2.6. The current ruby version is 2.5.0.
```

The [faraday@2.3.0](https://rubygems.org/gems/licensee/versions/9.12.0/dependencies) package is a run time dependency of licensee@9.12.0. And it requires RubyGem >= 2.6, [here](https://rubygems.org/gems/faraday/versions/2.3.0).

Changes:
1. Update RubyGem to 3.1.2 since ruby-build mark it as the latest stable release.
2. Remove `gem install nokogiri:1.12.5` because licensee@9.12.0 will install nokogiri:1.13.6 which requires RubyGem >= 2.6.0
3. gem options `--no-rdoc` and `--no-ri` are replaced with `--no-document`