### PR TITLE
Fix erroneous release dates in rubygem

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,7 +40,13 @@ function extractDate(dateAndTime, formats = dateTimeFormats) {
   for (let index = 0; !luxonResult.isValid && index < formats.length; index++) {
     luxonResult = DateTime.fromFormat(dateAndTime, formats[index])
   }
-  return luxonResult.isValid ? luxonResult : null
+
+  if (!luxonResult.isValid) return null
+
+  const instant = luxonResult.until(luxonResult)
+  const validStart =  DateTime.fromISO('1950-01-01')
+  const validEnd = DateTime.now().plus({ days: 30 })
+  return (instant.isBefore(validStart) || instant.isAfter(validEnd)) ? null : luxonResult
 }
 
 module.exports = { normalizePath, normalizePaths, trimParents, trimAllParents, extractDate }

--- a/test/unit/lib/utilsTests.js
+++ b/test/unit/lib/utilsTests.js
@@ -77,4 +77,8 @@ describe('Util extractDate', () => {
     const parsed = extractDate('2018-05-28 07:26:25 UTC')
     expect(parsed.toISODate()).to.be.eq('2018-05-28')
   })
+  it('ignores parseable date in the future', () => {
+    const parsed = extractDate('2103-09-30 00:00:00.000000000 Z')
+    expect(parsed).not.to.be.ok
+  })
 })

--- a/test/unit/providers/fetch/rubyGemsFetchTests.js
+++ b/test/unit/providers/fetch/rubyGemsFetchTests.js
@@ -25,7 +25,7 @@ describe('rubyGemsFetch', () => {
       sha1: 'f343d34992fffa1e4abbb1a2bfae45fcf49123ba',
       sha256: '2b5e4ba4e915e897d6fe9392c1cd1f5a21f8e7963679fb23f0a1953124772da0'
     })
-    expect(result.document.releaseDate).to.be.equal('2012-05-21')
+    expect(result.document.releaseDate).to.contain('2012-05-21')
   }
 
   it('fetch spec with version', async () => {


### PR DESCRIPTION
The date information in the metadata.txt can be incorrect.
For example:
date: 2103-09-30 00:00:00.000000000 Z
is in the extracted metadata.txt for gem/rubygems/-/gtl-sluggable/0.2.0.

1. Similar to utils.extractDate in service, ignore the dates beyond the
valid range in crawler.
2. In case of incorrect dates extracted from metadata.txt, infer the
release date from mTime of the decompressed metadata.gz.

Test cases:
1.
localhost:4000/definitions/gem/rubygems/-/super-app/0.0.1
"releaseDate": "2014-04-03" (https://rubygems.org/gems/gtl-sluggable/versions/0.1.0)
2.
localhost:4000/definitions/gem/rubygems/-/gtl-sluggable/0.2.0
"releaseDate": "2013-09-30" (https://rubygems.org/gems/super-app/versions)

Task: https://github.com/clearlydefined/website/issues/948