### PR TITLE
Fixed error creating scopedQueueSets

### DIFF
--- a/ghcrawler/crawlerFactory.js
+++ b/ghcrawler/crawlerFactory.js
@@ -220,7 +220,8 @@ class CrawlerFactory {
 
   static createScopedQueueSets(queueOptions) {
     const globalQueues = CrawlerFactory.createQueues(queueOptions)
-    const localQueues = CrawlerFactory.createQueues(queueOptions, 'memory')
+    const memoryOpts = { provider: 'memory', memory: queueOptions[queueOptions.provider] }
+    const localQueues = CrawlerFactory.createQueues(memoryOpts)
     return new ScopedQueueSets(globalQueues, localQueues)
   }
 }

--- a/test/unit/ghcrawler/crawlerFactoryTest.js
+++ b/test/unit/ghcrawler/crawlerFactoryTest.js
@@ -1,0 +1,47 @@
+// (c) Copyright 2022, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const { expect } = require('chai')
+const sinon = require('sinon')
+const CrawlerFactory = require('../../../ghcrawler/crawlerFactory')
+const MemoryFactory = require('../../../ghcrawler/providers/queuing/memoryFactory')
+
+describe('create scopedQueueSets', () => {
+
+  before(() => {
+    sinon.stub(CrawlerFactory, 'createQueues').callsFake((options, provider = options.provider) => {
+      const opts = options[provider] || {}
+      opts.logger = { info: sinon.stub() }
+      return MemoryFactory(opts)
+    })
+  })
+
+  after(() => {
+    sinon.restore()
+  })
+
+  it('should create ok with memory queue options', async () => {
+    const queueOptions = {
+      provider: 'memory',
+      memory: {
+        _config: { on: sinon.stub() },
+        weights: { immediate: 3, soon: 2, normal: 3, later: 2 },
+      }
+    }
+    const queues = CrawlerFactory.createScopedQueueSets(queueOptions)
+    expect(queues).to.be.ok
+  })
+
+  it('should create ok with non memory queue options', async () => {
+    const queueOptions = {
+      provider: 'storageQueue',
+      storageQueue: {
+        _config: { on: sinon.stub() },
+        weights: { immediate: 3, soon: 2, normal: 3, later: 2 },
+        queueName: 'cdcrawlerdev'
+      }
+    }
+    const queues = CrawlerFactory.createScopedQueueSets(queueOptions)
+    expect(queues).to.be.ok
+  })
+})


### PR DESCRIPTION
When creating scopedQueueSets with non memory global queues, there is error.
Fixed by passing a copy of global queue options for memory based local queue sets.