### PR TITLE
Turning on crawlers post-optimization

### DIFF
--- a/providers/process/abstractProcessor.js
+++ b/providers/process/abstractProcessor.js
@@ -229,7 +229,7 @@ class AbstractProcessor extends BaseHandler {
   }
 
   addLocalToolTasks(request, ...tools) {
-    const toolList = tools.length ? tools : ['scancode', /*'licensee', 'reuse', 'fossology'*/]
+    const toolList = tools.length ? tools : ['licensee', 'scancode', 'reuse'/*, 'fossology'*/]
     toolList.forEach(tool => this.linkAndQueueTool(request, tool, undefined, 'local'))
   }
 }

--- a/test/unit/providers/process/abstractProcessorTests.js
+++ b/test/unit/providers/process/abstractProcessorTests.js
@@ -181,11 +181,11 @@ describe('link and queue local tasks', () => {
   it('link and queue default local tasks', () => {
     const request = new Request('npm', 'cd:/npm/npmjs/-/redie/0.3.0')
     processor.addLocalToolTasks(request)
-    expect(processor.linkAndQueueTool.callCount).to.be.equal(1)
+    expect(processor.linkAndQueueTool.callCount).to.be.equal(3)
     expect(processor.linkAndQueueTool.args.map(call => call[1])).to.have.members([
-      //'licensee',
+      'licensee',
       'scancode',
-      //'reuse'
+      'reuse'
     ])
   })
 })

--- a/test/unit/providers/process/composerExtractTests.js
+++ b/test/unit/providers/process/composerExtractTests.js
@@ -49,11 +49,11 @@ describe('PHP processing', () => {
         expect(file.hashes.sha256).to.be.equal(hashes['symfony/polyfill-mbstring-1.11.0'][file.path].sha256)
       }
     })
-    expect(processor.linkAndQueueTool.callCount).to.be.equal(1)
+    expect(processor.linkAndQueueTool.callCount).to.be.equal(3)
     expect(processor.linkAndQueueTool.args.map(call => call[1])).to.have.members([
-      //'licensee',
+      'licensee',
       'scancode', /*, 'fossology'*/
-      //'reuse'
+      'reuse'
     ])
     expect(request.document.attachments.length).to.eq(1)
     expect(request.document.summaryInfo.count).to.be.equal(8)

--- a/test/unit/providers/process/crateExtractTests.js
+++ b/test/unit/providers/process/crateExtractTests.js
@@ -67,11 +67,11 @@ describe('Crate processing', () => {
       expect(file.hashes.sha1).to.be.equal(hashes['bitflags-1.0.4'][file.path].sha1)
       expect(file.hashes.sha256).to.be.equal(hashes['bitflags-1.0.4'][file.path].sha256)
     })
-    expect(processor.linkAndQueueTool.callCount).to.be.equal(1)
+    expect(processor.linkAndQueueTool.callCount).to.be.equal(3)
     expect(processor.linkAndQueueTool.args.map(call => call[1])).to.have.members([
-      //'licensee',
+      'licensee',
       'scancode',
-      //'reuse' /*, 'fossology'*/
+      'reuse' /*, 'fossology'*/
     ])
     expect(request.document.summaryInfo.count).to.be.equal(10)
     expect(processor.linkAndQueue.callCount).to.be.equal(1)

--- a/test/unit/providers/process/debExtractTests.js
+++ b/test/unit/providers/process/debExtractTests.js
@@ -13,11 +13,11 @@ describe('Debian processing', () => {
     await processor.handle(request)
 
     expect(request.document.sourceInfo.type).to.equal('debsrc')
-    expect(processor.linkAndQueueTool.callCount).to.be.equal(1)
+    expect(processor.linkAndQueueTool.callCount).to.be.equal(3)
     expect(processor.linkAndQueueTool.args.map(call => call[1])).to.have.members([
-      // 'licensee',
+      'licensee',
       'scancode',
-      //'reuse' /*, 'fossology'*/
+      'reuse' /*, 'fossology'*/
     ])
     expect(processor.linkAndQueue.callCount).to.be.equal(1)
     expect(processor.linkAndQueue.args[0][1]).to.equal('source')

--- a/test/unit/providers/process/goExtractTests.js
+++ b/test/unit/providers/process/goExtractTests.js
@@ -27,11 +27,11 @@ describe('Go processing', () => {
     processor.linkAndQueue = sinon.stub()
     await processor.handle(request)
 
-    expect(processor.linkAndQueueTool.callCount).to.be.equal(1)
+    expect(processor.linkAndQueueTool.callCount).to.be.equal(3)
     expect(processor.linkAndQueueTool.args.map(call => call[1])).to.have.members([
-      // 'licensee',
+      'licensee',
       'scancode',
-      // 'reuse'
+      'reuse'
     ])
     expect(request.document.registryData.licenses).to.be.deep.equal(licenses)
   })

--- a/test/unit/providers/process/npmExtractTests.js
+++ b/test/unit/providers/process/npmExtractTests.js
@@ -44,11 +44,11 @@ describe('NPM processing', () => {
       expect(file.hashes.sha1).to.be.equal(hashes['redie-0.3.0'][file.path].sha1)
       expect(file.hashes.sha256).to.be.equal(hashes['redie-0.3.0'][file.path].sha256)
     })
-    expect(processor.linkAndQueueTool.callCount).to.be.equal(1)
+    expect(processor.linkAndQueueTool.callCount).to.be.equal(3)
     expect(processor.linkAndQueueTool.args.map(call => call[1])).to.have.members([
-      // 'licensee',
+      'licensee',
       'scancode',
-      //'reuse' /*, 'fossology'*/
+      'reuse' /*, 'fossology'*/
     ])
     expect(request.document.attachments.length).to.eq(2)
     expect(request.document._attachments.length).to.eq(2)

--- a/test/unit/providers/process/nugetExtractTests.js
+++ b/test/unit/providers/process/nugetExtractTests.js
@@ -64,11 +64,11 @@ describe('NuGet processing', () => {
       expect(file.hashes.sha1).to.be.equal(hashes['xunit.core.2.4.1'][file.path].sha1)
       expect(file.hashes.sha256).to.be.equal(hashes['xunit.core.2.4.1'][file.path].sha256)
     })
-    expect(processor.linkAndQueueTool.callCount).to.be.equal(1)
+    expect(processor.linkAndQueueTool.callCount).to.be.equal(3)
     expect(processor.linkAndQueueTool.args.map(call => call[1])).to.have.members([
-      //'licensee',
+      'licensee',
       'scancode',
-      //'reuse'
+      'reuse'
     ])
     expect(request.document.summaryInfo.count).to.be.equal(9)
     expect(processor.linkAndQueue.callCount).to.be.equal(1)

--- a/test/unit/providers/process/sourceTests.js
+++ b/test/unit/providers/process/sourceTests.js
@@ -16,12 +16,12 @@ describe('Source processing', () => {
     const request = mockRequest('cd:/sourcearchive/mavengoogle/android.arch.lifecycle/common/1.0.1')
     processor.handle(request)
 
-    expect(processor.linkAndQueueTool.callCount).to.be.equal(2)
+    expect(processor.linkAndQueueTool.callCount).to.be.equal(4)
     expect(processor.linkAndQueueTool.args.map(call => call[1])).to.have.members([
       'clearlydefined',
-      // 'licensee',
+      'licensee',
       'scancode',
-      // 'reuse'
+      'reuse'
     ])
   })
 })


### PR DESCRIPTION
licensee and reuse were previously turned off to help with cost temporary reductions. @qtomlinson has addressed performance issues in #475 so we're turning these back on