### PR TITLE
Upgrading ado pipelines to use ubuntu-latest

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
 pool:
-  vmImage: 'ubuntu-18.04'
+  vmImage: 'ubuntu-20.04'
 
 steps:
   - task: NodeTool@0


### PR DESCRIPTION
The ADO pipeline has been failing to build the docker image ever since ubuntu 18.04 has been deprecated. Upgrading to the recommended 20.04 should fix this issue.

`
##[warning]The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002
Pool: [Azure Pipelines](https://dev.azure.com/clearlydefined/5f0af3ae-1034-4f8f-9530-e4ab778fe2fb/_settings/agentqueues?poolId=&queueId=15)
Image: ubuntu-18.04
Agent: Hosted Agent
Started: Yesterday at 10:23 AM
Duration: 6m 3s
`