### PR TITLE
installing public_suffix in dockerfiles to fix licensee build break

### DIFF
--- a/DevDockerfile
+++ b/DevDockerfile
@@ -30,7 +30,7 @@ ENV SCANCODE_HOME=/usr/local/bin
 # So we pin to the previous version of nokogiri and faraday.
 RUN gem install nokogiri:1.12.5 --no-rdoc --no-ri && \
   gem install faraday:1.10.0 --no-rdoc --no-ri && \
-  gem install public_suffix -v 4.0.7 --no-rdoc --no-ri && \
+  gem install public_suffix:4.0.7 --no-rdoc --no-ri && \
   gem install licensee:9.12.0 --no-rdoc --no-ri
 
 # REUSE

--- a/DevDockerfile
+++ b/DevDockerfile
@@ -30,6 +30,7 @@ ENV SCANCODE_HOME=/usr/local/bin
 # So we pin to the previous version of nokogiri and faraday.
 RUN gem install nokogiri:1.12.5 --no-rdoc --no-ri && \
   gem install faraday:1.10.0 --no-rdoc --no-ri && \
+  gem install public_suffix -v 4.0.7 --no-rdoc --no-ri && \
   gem install licensee:9.12.0 --no-rdoc --no-ri
 
 # REUSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ ENV SCANCODE_HOME=/usr/local/bin
 # So we pin to the previous version of nokogiri and faraday.
 RUN gem install nokogiri:1.12.5 --no-rdoc --no-ri && \
   gem install faraday:1.10.0 --no-rdoc --no-ri && \
-  gem install public_suffix -v 4.0.7 --no-rdoc --no-ri && \
+  gem install public_suffix:4.0.7 --no-rdoc --no-ri && \
   gem install licensee:9.12.0 --no-rdoc --no-ri
 
 # REUSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ ENV SCANCODE_HOME=/usr/local/bin
 # So we pin to the previous version of nokogiri and faraday.
 RUN gem install nokogiri:1.12.5 --no-rdoc --no-ri && \
   gem install faraday:1.10.0 --no-rdoc --no-ri && \
+  gem install public_suffix -v 4.0.7 --no-rdoc --no-ri && \
   gem install licensee:9.12.0 --no-rdoc --no-ri
 
 # REUSE


### PR DESCRIPTION
Builds were breaking when installing Licensee. The breaking output was:

`ERROR:  Error installing licensee:
	The last version of public_suffix (< 6.0, >= 2.0.2) to support your Ruby & RubyGems was 4.0.7. Try installing it with `gem install public_suffix -v 4.0.7` and then running the current command again
	public_suffix requires Ruby version >= 2.6. The current ruby version is 2.5.0.
Successfully installed rugged-0.99.0
Successfully installed reverse_markdown-1.4.0
The command '/bin/sh -c gem install nokogiri:1.12.5 --no-rdoc --no-ri &&   gem install faraday:1.10.0 --no-rdoc --no-ri &&   gem install licensee:9.12.0 --no-rdoc --no-ri' returned a non-zero code: 1
##[error]The command '/bin/sh -c gem install nokogiri:1.12.5 --no-rdoc --no-ri &&   gem install faraday:1.10.0 --no-rdoc --no-ri &&   gem install licensee:9.12.0 --no-rdoc --no-ri' returned a non-zero code: 1
##[error]The process '/usr/bin/docker' failed with exit code 1
`