### PR TITLE
Fix failing scancode run in deployment

### DIFF
--- a/DevDockerfile
+++ b/DevDockerfile
@@ -16,8 +16,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends --no-install-su
   gem install bundler --no-rdoc --no-ri
 
 # Scancode
+ARG SCANCODE_VERSION="30.1.0"
 RUN pip3 install --upgrade pip setuptools wheel && \
-  pip3 install scancode-toolkit==30.1.0 && \
+  curl -Os https://raw.githubusercontent.com/nexB/scancode-toolkit/v$SCANCODE_VERSION/requirements.txt && \
+  pip3 install --constraint requirements.txt scancode-toolkit==$SCANCODE_VERSION && \
+  rm requirements.txt && \
   scancode --reindex-licenses && \
   scancode --version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends --no-install-su
   gem install bundler --no-rdoc --no-ri
 
 # Scancode
+ARG SCANCODE_VERSION="30.1.0"
 RUN pip3 install --upgrade pip setuptools wheel && \
-  pip3 install scancode-toolkit==30.1.0 && \
+  curl -Os https://raw.githubusercontent.com/nexB/scancode-toolkit/v$SCANCODE_VERSION/requirements.txt && \
+  pip3 install --constraint requirements.txt scancode-toolkit==$SCANCODE_VERSION && \
+  rm requirements.txt && \
   scancode --reindex-licenses && \
   scancode --version
 


### PR DESCRIPTION
Fix scancode install by fetching the corresponding requirement.txt from the git repo as a constraint file for pip installation.  Details see discussion at https://github.com/nexB/scancode-toolkit/issues/3107