### PR TITLE
Fix "stdout maxBuffer length exceeded" error in reuse processor

### DIFF
--- a/test/unit/providers/process/fsfeReuseTests.js
+++ b/test/unit/providers/process/fsfeReuseTests.js
@@ -6,7 +6,6 @@ const expect = chai.expect
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const sandbox = sinon.createSandbox()
-const fs = require('fs')
 const path = require('path')
 const { request } = require('../../../../ghcrawler')
 
@@ -90,7 +89,7 @@ describe('FSFE REUSE software process', () => {
         if (parameters.includes('--version')) {
           return callbackOrOptions(resultBox.versionError, { stdout: resultBox.versionResult })
         }
-        callback(resultBox.error, { stdout: fs.readFileSync(`${callbackOrOptions.cwd}/output.txt`).toString() })
+        callback(resultBox.error, {})
       }
     }
     const fsStub = { readdirSync: () => resultBox.licensesDirectory }
@@ -111,6 +110,7 @@ function setup(fixture, error, versionError) {
   Handler._resultBox.error = error
   Handler._resultBox.versionError = versionError
   const processor = Handler(options)
+  processor.createTempFile = sinon.stub().returns({ name: `test/fixtures/fsfeReuse/${fixture}/output.txt`})
   //processor.attachFiles = sinon.stub()
   return { request: testRequest, processor }
 }


### PR DESCRIPTION
Current reuse processing utilizes stdout with a predetermined buffer size. The buffer size is not enough for some large packages. Use the file output to overcome the buffer size limit.

Command 'docker run --rm --volume $(pwd):/data fsfe/reuse spdx --help' shows --output or -o can be used to specify an output file

Additional documentation:
-reuse documentation
(https://reuse.readthedocs.io/en/stable/readme.html#run-in-docker) 
-reuse codebase
https://git.fsfe.org/reuse/tool/src/commit/2b0d470919f98625f31b64819c889b0c54fc0180/src/reuse/spdx.py#L27

Task: https://github.com/clearlydefined/crawler/issues/494