### PR TITLE
Use InMemoryCrawlerQueue as local queue

### DIFF
--- a/ghcrawler/providers/queuing/inmemoryQueueManager.js
+++ b/ghcrawler/providers/queuing/inmemoryQueueManager.js
@@ -1,0 +1,13 @@
+// (c) Copyright 2022, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const AttenuatedQueue = require('./attenuatedQueue')
+const InMemoryCrawlQueue = require('./inmemorycrawlqueue')
+
+class InMemoryQueueManager {
+  createQueueChain(name, options) {
+    return new AttenuatedQueue(new InMemoryCrawlQueue(name, options), options)
+  }
+}
+
+module.exports = InMemoryQueueManager

--- a/ghcrawler/providers/queuing/memoryFactory.js
+++ b/ghcrawler/providers/queuing/memoryFactory.js
@@ -2,14 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 const CrawlerFactory = require('../../crawlerFactory')
-const AttenuatedQueue = require('./attenuatedQueue')
-const InMemoryCrawlQueue = require('./inmemorycrawlqueue')
+const InMemoryQueueManager = require('./inmemoryQueueManager')
 
 module.exports = options => {
-  const manager = {
-    createQueueChain: (name, options) => {
-      return new AttenuatedQueue(new InMemoryCrawlQueue(name, options), options)
-    }
-  }
+  const manager = new InMemoryQueueManager()
   return CrawlerFactory.createScopedQueueSets({ globalManager: manager, localManager: manager }, options)
 }

--- a/ghcrawler/providers/queuing/storageQueueFactory.js
+++ b/ghcrawler/providers/queuing/storageQueueFactory.js
@@ -3,11 +3,11 @@
 
 const StorageQueueManager = require('./storageQueueManager')
 const CrawlerFactory = require('../../crawlerFactory')
-const StorageBackedInMemoryQueueManager = require('./storageBackedInMemoryQueueManager')
+const InMemoryQueueManager = require('./inmemoryQueueManager')
 
 module.exports = options => {
   const { connectionString } = options
-  const storageQueueManager = new StorageQueueManager(connectionString, options)
-  const localManager = new StorageBackedInMemoryQueueManager(storageQueueManager)
-  return CrawlerFactory.createScopedQueueSets({ globalManager: storageQueueManager, localManager}, options)
+  const storageQueueManager = new StorageQueueManager(connectionString)
+  const localManager = new InMemoryQueueManager()
+  return CrawlerFactory.createScopedQueueSets({ globalManager: storageQueueManager, localManager }, options)
 }


### PR DESCRIPTION
Using StorageBackedQueue for local queue solved the problem of loosing local tool tasks (requests) during shutdown. This comes at a increased cost than in-memory queue, and is the same cost as the storage queue in production.

Shutdown or restart are infrequent events. To reduce cost, use InMemoryCrawlerQueue as local queue instead for now.

Task: https://github.com/clearlydefined/crawler/issues/482