### PR TITLE
Fixed "stdout maxBuffer length exceeded" error during licensee proces…

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 const { DateTime } = require('luxon')
+const { spawn } = require('child_process')
 
 const dateTimeFormats = [
   'EEE MMM d HH:mm:ss \'GMT\'ZZ yyyy'   //in pom properties
@@ -49,4 +50,30 @@ function extractDate(dateAndTime, formats = dateTimeFormats) {
   return (instant.isBefore(validStart) || instant.isAfter(validEnd)) ? null : luxonResult
 }
 
-module.exports = { normalizePath, normalizePaths, trimParents, trimAllParents, extractDate }
+function attachListeners(child, resolve, reject) {
+  let stdoutData = '', stderrData = '', error
+
+  child.stdout.on('data', chunk => stdoutData = stdoutData ? stdoutData + chunk : chunk)
+  child.stderr.on('data', chunk => stderrData = stderrData ? stderrData + chunk : chunk)
+
+  child
+  .on('error', (err) => error = err)
+  .on('close', (code) => {
+    if (code === 0) resolve(stdoutData.toString())
+    else if (error) reject(error)
+    else {
+      const errorFromChild = new Error(stderrData.toString())
+      errorFromChild.code = code
+      reject(errorFromChild)
+    }
+  })
+}
+
+function spawnPromisified(command, args, options) {
+  const childProcess = spawn(command, args, options)
+  return new Promise((resolve, reject) => {
+    attachListeners(childProcess, resolve, reject)
+  })
+}
+
+module.exports = { normalizePath, normalizePaths, trimParents, trimAllParents, extractDate, spawnPromisified }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -51,18 +51,17 @@ function extractDate(dateAndTime, formats = dateTimeFormats) {
 }
 
 function attachListeners(child, resolve, reject) {
-  let stdoutData = '', stderrData = '', error
+  let stdoutData = [], stderrData = []
 
-  child.stdout.on('data', chunk => stdoutData = stdoutData ? stdoutData + chunk : chunk)
-  child.stderr.on('data', chunk => stderrData = stderrData ? stderrData + chunk : chunk)
+  child.stdout.on('data', chunk => stdoutData.push(chunk))
+  child.stderr.on('data', chunk => stderrData.push(chunk))
 
   child
-  .on('error', (err) => error = err)
+  .on('error', (err) => reject(err))
   .on('close', (code) => {
-    if (code === 0) resolve(stdoutData.toString())
-    else if (error) reject(error)
+    if (code === 0) resolve(stdoutData.join(''))
     else {
-      const errorFromChild = new Error(stderrData.toString())
+      const errorFromChild = new Error(stderrData.join(''))
       errorFromChild.code = code
       reject(errorFromChild)
     }

--- a/test/unit/lib/utilsTests.js
+++ b/test/unit/lib/utilsTests.js
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 const expect = require('chai').expect
-const { normalizePath, normalizePaths, trimParents, trimAllParents, extractDate } = require('../../../lib/utils')
+const { normalizePath, normalizePaths, trimParents, trimAllParents, extractDate, spawnPromisified } = require('../../../lib/utils')
+const { promisify } = require('util')
+const execFile = promisify(require('child_process').execFile)
 
 describe('Utils path functions', () => {
   it('normalizes one path', () => {
@@ -82,3 +84,35 @@ describe('Util extractDate', () => {
     expect(parsed).not.to.be.ok
   })
 })
+
+describe('test spawnPromisified ', () => {
+
+  it('test spawn success + command success', async () => {
+    const { stdout: expected} = await execFile('ls', ['-l'])
+    const actual = await spawnPromisified('ls', ['-l'])
+    expect(actual).to.be.equal(expected)
+  })
+
+  it('test spawn success + command failure', async () => {
+    const expectedError = await getError(execFile('cat', ['t.txt']))
+    const actualError = await getError(spawnPromisified('cat', ['t.txt']))
+    expect(expectedError.code).to.be.equal(actualError.code)
+    expect(expectedError.message).to.include(actualError.message)
+  })
+
+  it('test spawn failure', async () => {
+    const expectedError = await getError(execFile('f', ['t.txt']))
+    const actualError = await getError(spawnPromisified('f', ['t.txt']))
+    expect(expectedError.code).to.be.equal(actualError.code)
+    expect(expectedError.message).to.be.equal(actualError.message)
+  })
+})
+
+async function getError(promise) {
+  try {
+    await promise
+  } catch (error) {
+    return error
+  }
+}
+

--- a/test/unit/lib/utilsTests.js
+++ b/test/unit/lib/utilsTests.js
@@ -1,10 +1,13 @@
 // Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
-const expect = require('chai').expect
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
 const { normalizePath, normalizePaths, trimParents, trimAllParents, extractDate, spawnPromisified } = require('../../../lib/utils')
 const { promisify } = require('util')
 const execFile = promisify(require('child_process').execFile)
+chai.use(chaiAsPromised)
+const expect = chai.expect
 
 describe('Utils path functions', () => {
   it('normalizes one path', () => {
@@ -87,24 +90,35 @@ describe('Util extractDate', () => {
 
 describe('test spawnPromisified ', () => {
 
-  it('test spawn success + command success', async () => {
+  it('should handle spawn + command successfully', async () => {
     const { stdout: expected} = await execFile('ls', ['-l'])
     const actual = await spawnPromisified('ls', ['-l'])
     expect(actual).to.be.equal(expected)
   })
 
-  it('test spawn success + command failure', async () => {
+  it('should throw for spawn success + command failure', async () => {
     const expectedError = await getError(execFile('cat', ['t.txt']))
     const actualError = await getError(spawnPromisified('cat', ['t.txt']))
     expect(expectedError.code).to.be.equal(actualError.code)
     expect(expectedError.message).to.include(actualError.message)
   })
 
-  it('test spawn failure', async () => {
+  it('should throw for spawn failure', async () => {
     const expectedError = await getError(execFile('f', ['t.txt']))
     const actualError = await getError(spawnPromisified('f', ['t.txt']))
     expect(expectedError.code).to.be.equal(actualError.code)
     expect(expectedError.message).to.be.equal(actualError.message)
+  })
+
+  it('should handle output more than 5MB', async () => {
+    const largeFile = 'test/fixtures/debian/0ad_0.0.17-1_armhf.deb'
+    const execFilePromise = execFile('cat', [largeFile, largeFile], {
+      maxBuffer: 5 * 1024 * 1024
+    })
+    await expect(execFilePromise).to.be.rejectedWith('stdout maxBuffer length exceeded')
+
+    const output = await spawnPromisified('cat', [largeFile, largeFile])
+    expect(output).to.be.ok
   })
 })
 

--- a/test/unit/providers/process/licenseeTests.js
+++ b/test/unit/providers/process/licenseeTests.js
@@ -54,11 +54,9 @@ describe('Licensee process', () => {
   beforeEach(function() {
     const resultBox = { error: null, versionResult: '1.2.0', versionError: null }
     const processStub = {
-      execFile: (command, parameters, callbackOrOptions, callback) => {
+      execFile: (command, parameters, callbackOrOptions) => {
         if (parameters.includes('version'))
           return callbackOrOptions(resultBox.versionError, { stdout: resultBox.versionResult })
-        const path = parameters.slice(-1)[0]
-        callback(resultBox.error, { stdout: fs.readFileSync(`${path}/output.json`).toString() })
       }
     }
     Handler = proxyquire('../../../../providers/process/licensee', { child_process: processStub })
@@ -78,6 +76,9 @@ function setup(fixture, error, versionError) {
   Handler._resultBox.error = error
   Handler._resultBox.versionError = versionError
   const processor = Handler(options)
+  processor._runLicensee = error ?
+    sinon.stub().rejects(error) :
+    (parameters, inputFolder) => Promise.resolve(fs.readFileSync(`${inputFolder}/output.json`).toString())
   processor.attachFiles = sinon.stub()
   return { request: testRequest, processor }
 }


### PR DESCRIPTION
The maxBuffer was adjusted previously and is still not enough for certain large packages.  Licensee is invoked many times (one folder for each invocation) during processing one package. In most licensee invocations, the output is small.  To acommodate large output in some invocation, use spawn instead.

Task: https://github.com/clearlydefined/crawler/issues/503