### PR TITLE
lowercasing package names for nuget api fetching

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
   "editor.folding": false,
   "editor.tabSize": 2,
   "editor.detectIndentation": false,
-  "editor.formatOnSave": true,
+  "editor.formatOnSave": false,
   "editor.formatOnType": true,
   "editor.insertSpaces": true,
   "files.trimTrailingWhitespace": true

--- a/providers/fetch/nugetFetch.js
+++ b/providers/fetch/nugetFetch.js
@@ -120,7 +120,7 @@ class NuGetFetch extends AbstractFetch {
     // https://docs.microsoft.com/en-us/nuget/api/package-base-address-resource#download-package-manifest-nuspec
     // Example: https://api.nuget.org/v3-flatcontainer/newtonsoft.json/11.0.1/newtonsoft.json.nuspec
     const { body, statusCode } = await requestRetry.get(
-      `https://api.nuget.org/v3-flatcontainer/${spec.name}/${spec.revision}/${spec.name}.nuspec`
+      `https://api.nuget.org/v3-flatcontainer/${spec.name.toLowerCase()}/${spec.revision}/${spec.name.toLowerCase()}.nuspec`
     )
     if (statusCode !== 200) return null
     return body


### PR DESCRIPTION
Calls to `https://api.nuget.org/v3-flatcontainer/${spec.name}/${spec.revision}/${spec.name}.nuspec` were failing when components contained uppercase chars thus marking them as "missing" when attempting to harvest.

This update lowercases all nuget component names before calling the nuget api