### PR TITLE
Fix harvesting git components

### DIFF
--- a/DevDockerfile
+++ b/DevDockerfile
@@ -40,6 +40,8 @@ RUN gem install nokogiri:1.12.5 --no-document && \
 RUN pip3 install setuptools
 RUN pip3 install reuse
 
+RUN git config --global --add safe.directory '*'
+
 COPY package*.json /tmp/
 RUN cd /tmp && npm install
 RUN mkdir -p "${APPDIR}" && cp -a /tmp/node_modules "${APPDIR}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,8 @@ ENV CRAWLER_STORE_PROVIDER=cdDispatch+cd(azblob)+azqueue
 ENV CRAWLER_WEBHOOK_URL=https://api.clearlydefined.io/webhook
 ENV CRAWLER_AZBLOB_CONTAINER_NAME=production
 
+RUN git config --global --add safe.directory '*'
+
 COPY package*.json /tmp/
 RUN cd /tmp && npm install --production
 RUN mkdir -p "${APPDIR}" && cp -a /tmp/node_modules "${APPDIR}"


### PR DESCRIPTION
The latest node:16 docker image contains debian/git 1:2.20.1-2+deb10u8.  Change log at https://tracker.debian.org/pkg/git shows "[2022-12-13] Accepted git 1:2.20.1-2+deb10u5 (source) into oldstable (Sylvain Beucler)".  The related changes (https://tracker.debian.org/news/1398381/accepted-git-12201-2deb10u5-source-into-oldstable/) include fix for CVE-2022-24765.  It is also noted that "The above introduces new 'safe.directory' checks which may cause regressions: allow opt-out of such checks with 'safe.directory=*'"  This is the root cause for "fatal: detected dubious ownership in repository at " exception during harvesting git components.  Fixed this by opting-out of such checks with 'safe.directory=*'

Task: https://github.com/clearlydefined/crawler/issues/516