### PR TITLE
add deploy script for crawler

### DIFF
--- a/.github/workflows/build-and-deploy-dev.yml
+++ b/.github/workflows/build-and-deploy-dev.yml
@@ -1,0 +1,15 @@
+# This workflow will build a docker image, push it to ghcr.io, and deploy it to an Azure WebApp.
+name: Build and Deploy to dev crawler app
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+
+jobs:
+  build-and-deploy:
+    uses: clearlydefined/operations/.github/workflows/build-and-deploy-dev.yml@elr/shared-dev-deploy
+    secrets: inherit
+    with:
+      application-name: "cdcrawler"
+      application-type: "worker"


### PR DESCRIPTION
DO NOT MERGE

* The shared script in [cd/operations PR #69](https://github.com/clearlydefined/operations/pull/68) must be merged first.
* The reference to the branch in that PR should be updated to a sha once it is merged.
* Need to turn off any deploys happening through Azure DevOpts

----

### Description

This adds the ability to deploy the dev crawler to Azure using the shared deploy script in clearlydefined/operations.


