### PR TITLE
Fix URL to fetch Go packages with latest version

### DIFF
--- a/providers/fetch/goFetch.js
+++ b/providers/fetch/goFetch.js
@@ -69,7 +69,8 @@ class GoFetch extends AbstractFetch {
   }
 
   async _getLatestVersion(spec) {
-    const initial_url = `https://${spec.provider}/${spec.namespace}/${spec.name}/@v/list`
+    //const initial_url = `https://${spec.provider}/${spec.namespace}/${spec.name}/@v/list`
+    const initial_url = `https://proxy.golang.org/${spec.namespace}/${spec.name}/@v/list`
     const replace_encoded_url = this._replace_encodings(initial_url)
     const url = replace_encoded_url.replace(/null\//g, '')
 

--- a/providers/fetch/goFetch.js
+++ b/providers/fetch/goFetch.js
@@ -69,7 +69,6 @@ class GoFetch extends AbstractFetch {
   }
 
   async _getLatestVersion(spec) {
-    //const initial_url = `https://${spec.provider}/${spec.namespace}/${spec.name}/@v/list`
     const initial_url = `https://proxy.golang.org/${spec.namespace}/${spec.name}/@v/list`
     const replace_encoded_url = this._replace_encodings(initial_url)
     const url = replace_encoded_url.replace(/null\//g, '')

--- a/providers/fetch/goFetch.js
+++ b/providers/fetch/goFetch.js
@@ -9,6 +9,10 @@ const { parse: htmlParser } = require('node-html-parser')
 const { parse: spdxParser } = require('@clearlydefined/spdx')
 const FetchResult = require('../../lib/fetchResult')
 
+const providerMap = {
+  golang: 'https://proxy.golang.org'
+}
+
 class GoFetch extends AbstractFetch {
   constructor(options) {
     super(options)
@@ -69,7 +73,7 @@ class GoFetch extends AbstractFetch {
   }
 
   async _getLatestVersion(spec) {
-    const initial_url = `https://proxy.golang.org/${spec.namespace}/${spec.name}/@v/list`
+    const initial_url = `${providerMap.golang}/${spec.namespace}/${spec.name}/@v/list`
     const replace_encoded_url = this._replace_encodings(initial_url)
     const url = replace_encoded_url.replace(/null\//g, '')
 
@@ -89,7 +93,7 @@ class GoFetch extends AbstractFetch {
   }
 
   _buildUrl(spec, extension = '.zip') {
-    let initial_url = `https://proxy.golang.org/${spec.namespace}/${spec.name}/@v/${spec.revision}${extension}`
+    let initial_url = `${providerMap.golang}/${spec.namespace}/${spec.name}/@v/${spec.revision}${extension}`
     return this._replace_encodings(this._remove_blank_fields(initial_url))
   }
 

--- a/test/unit/providers/fetch/goFetchTests.js
+++ b/test/unit/providers/fetch/goFetchTests.js
@@ -9,16 +9,16 @@ const Request = require('../../../../ghcrawler').request
 const fs = require('fs')
 const { merge } = require('lodash')
 
-const stub = 'https://proxy.golang.org/'
+const goBaseURL = 'https://proxy.golang.org/'
 
 describe('Go utility functions', () => {
   it('builds URLs', () => {
     const fetch = GoFetch({})
-    expect(fetch._buildUrl(spec('go', 'golang', 'cloud.google.com', 'go', 'v0.56.0'))).to.equal(stub + 'cloud.google.com/go/@v/v0.56.0.zip')
-    expect(fetch._buildUrl(spec('go', 'golang', 'cloud.google.com', 'go', 'v0.56.0'), '.mod')).to.equal(stub + 'cloud.google.com/go/@v/v0.56.0.mod')
-    expect(fetch._buildUrl(spec('go', 'golang', '-', 'collectd.org', 'v0.5.0'))).to.equal(stub + 'collectd.org/@v/v0.5.0.zip')
-    expect(fetch._buildUrl(spec('go', 'golang', 'github.com%2fAzure%2fazure-event-hubs-go', 'v3', 'v3.2.0'))).to.equal(stub + 'github.com/Azure/azure-event-hubs-go/v3/@v/v3.2.0.zip')
-    expect(fetch._buildUrl(spec('go', 'golang', 'github.com%2FAzure%2Fazure-event-hubs-go', 'v3', 'v3.2.0'))).to.equal(stub + 'github.com/Azure/azure-event-hubs-go/v3/@v/v3.2.0.zip')
+    expect(fetch._buildUrl(spec('go', 'golang', 'cloud.google.com', 'go', 'v0.56.0'))).to.equal(goBaseURL + 'cloud.google.com/go/@v/v0.56.0.zip')
+    expect(fetch._buildUrl(spec('go', 'golang', 'cloud.google.com', 'go', 'v0.56.0'), '.mod')).to.equal(goBaseURL + 'cloud.google.com/go/@v/v0.56.0.mod')
+    expect(fetch._buildUrl(spec('go', 'golang', '-', 'collectd.org', 'v0.5.0'))).to.equal(goBaseURL + 'collectd.org/@v/v0.5.0.zip')
+    expect(fetch._buildUrl(spec('go', 'golang', 'github.com%2fAzure%2fazure-event-hubs-go', 'v3', 'v3.2.0'))).to.equal(goBaseURL + 'github.com/Azure/azure-event-hubs-go/v3/@v/v3.2.0.zip')
+    expect(fetch._buildUrl(spec('go', 'golang', 'github.com%2FAzure%2Fazure-event-hubs-go', 'v3', 'v3.2.0'))).to.equal(goBaseURL + 'github.com/Azure/azure-event-hubs-go/v3/@v/v3.2.0.zip')
   })
 })
 
@@ -47,7 +47,7 @@ describe('Go Proxy fetching', () => {
   beforeEach(() => {
     const requestPromiseStub = options => {
       if (options.url) {
-        expect(options.url).to.contain(stub)
+        expect(options.url).to.contain(goBaseURL)
         if (options.url.includes('error')) throw new Error('yikes')
         if (options.url.includes('code')) throw { statusCode: 500, message: 'Code' }
         if (options.url.includes('missing')) throw { statusCode: 404 }

--- a/test/unit/providers/fetch/goFetchTests.js
+++ b/test/unit/providers/fetch/goFetchTests.js
@@ -47,6 +47,7 @@ describe('Go Proxy fetching', () => {
   beforeEach(() => {
     const requestPromiseStub = options => {
       if (options.url) {
+        expect(options.url).to.contain(stub)
         if (options.url.includes('error')) throw new Error('yikes')
         if (options.url.includes('code')) throw { statusCode: 500, message: 'Code' }
         if (options.url.includes('missing')) throw { statusCode: 404 }


### PR DESCRIPTION
- [ ] The URL used in the _getLatestVersion function has been corrected as below.

     - Previous URL used - `const initial_url = 'https://${spec.provider}/${spec.namespace}/${spec.name}/@v/list'` where the value of `${spec.provider}` is *golang* which forms an incorrect URL.

    - Working URL updated to - `const initial_url = 'https://proxy.golang.org/${spec.namespace}/${spec.name}/@v/list'`

- [ ] Test case has been added to check the incoming URL to contain `https://proxy.golang.org` in all the go package requests.

- [ ] Updated providerMap variable to maintain the consistency of URL used throughout *goFetch.js* file.
- [ ] Variable name updated in the *goFetchTests.js* file from *stub* to *goBaseURL* for better understanding.