### PR TITLE
Fix ENOENT error during harvesting Conda components

### DIFF
--- a/providers/fetch/condaFetch.js
+++ b/providers/fetch/condaFetch.js
@@ -11,7 +11,7 @@ const FetchResult = require('../../lib/fetchResult')
 class CondaFetch extends AbstractFetch {
   constructor(options) {
     super(options)
-    this.packageMapFolder = this.options.cdFileLocation
+    this.packageMapPrefix = this.options.cdFileLocation
     this.channels = {
       'anaconda-main': 'https://repo.anaconda.com/pkgs/main',
       'anaconda-r': 'https://repo.anaconda.com/pkgs/r',
@@ -210,7 +210,7 @@ class CondaFetch extends AbstractFetch {
       `${condaChannelID}-channelDataFile`,
       `${condaChannelUrl}/channeldata.json`,
       this.CACHE_DURATION,
-      `${this.packageMapFolder}/${condaChannelID}-channelDataFile.json`
+      `${this.packageMapPrefix}-${condaChannelID}-channelDataFile.json`
     )
   }
 
@@ -219,7 +219,7 @@ class CondaFetch extends AbstractFetch {
       `${condaChannelID}-repoDataFile-${architecture}`,
       `${condaChannelUrl}/${architecture}/repodata.json`,
       this.CACHE_DURATION,
-      `${this.packageMapFolder}/${condaChannelID}-repoDataFile-${architecture}.json`
+      `${this.packageMapPrefix}-${condaChannelID}-repoDataFile-${architecture}.json`
     )
   }
 }


### PR DESCRIPTION
This is to fix [ENONET exception](https://github.com/clearlydefined/crawler/issues/568#issuecomment-2098910877)  encountered during testing on dev deployment. It follows the same approach taken in [debianFetch.js](https://github.com/clearlydefined/crawler/blob/473a5603c8a149649c4de46f144dc9432ab452cf/providers/fetch/debianFetch.js#L40).