### PR TITLE
Make Crawler queue in Azure separate from Azure results storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,3 +277,4 @@ This project welcomes contributions and suggestions, and we've documented the de
 
 The [Code of Conduct](CODE_OF_CONDUCT.md) for this project is details how the community interacts in
 an inclusive and respectful manner. Please keep it in mind as you engage here.
+

--- a/README.md
+++ b/README.md
@@ -147,6 +147,17 @@ See `local.env.list`, `dev.env.list` and `prod.env.list` tempate files.
 - Allowed resource types: Container, Object
 - Allowed permissions: Read, Write, List, Add, Process
 
+### Running Crawler Queues in separate Azure account
+
+Crawler can be run with the queues in a different Azure account from the storage
+blobs. This is useful where you are running the crawler and submitting results
+to `clearlydefinedprod` *but* you don't want to have queues in the same Azure
+account. As anyone with access to `clearlydefinedprod` can get access to your
+queues.
+
+Set env var `CRAWLER_QUEUE_AZURE_CONNECTION_STRING` with a connection string
+obtained from Azure.
+
 ## Build and run Docker image locally
 
 `docker build --platform linux/amd64 -t cdcrawler:latest .`

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ See `local.env.list`, `dev.env.list` and `prod.env.list` tempate files.
 
 Crawler can be run with the queues in a different Azure account from the storage
 blobs. This is useful where you are running the crawler and submitting results
-to `clearlydefinedprod` *but* you don't want to have queues in the same Azure
+to `clearlydefinedprod` _but_ you don't want to have queues in the same Azure
 account. As anyone with access to `clearlydefinedprod` can get access to your
 queues.
 

--- a/README.md
+++ b/README.md
@@ -277,4 +277,3 @@ This project welcomes contributions and suggestions, and we've documented the de
 
 The [Code of Conduct](CODE_OF_CONDUCT.md) for this project is details how the community interacts in
 an inclusive and respectful manner. Please keep it in mind as you engage here.
-

--- a/config/cdConfig.js
+++ b/config/cdConfig.js
@@ -127,7 +127,7 @@ module.exports = {
     },
     storageQueue: {
       weights: { immediate: 3, soon: 2, normal: 3, later: 2 },
-      connectionString: config.get('CRAWLER_QUEUE_CONNECTION_STRING') || cd_azblob.connection,
+      connectionString: config.get('CRAWLER_QUEUE_AZURE_CONNECTION_STRING') || cd_azblob.connection,
       queueName: config.get('CRAWLER_QUEUE_PREFIX') || 'cdcrawlerdev',
       visibilityTimeout: 8 * 60 * 60, // 8 hours
       visibilityTimeout_remainLocal: fetchedCacheTtlSeconds,

--- a/config/cdConfig.js
+++ b/config/cdConfig.js
@@ -127,7 +127,7 @@ module.exports = {
     },
     storageQueue: {
       weights: { immediate: 3, soon: 2, normal: 3, later: 2 },
-      connectionString: cd_azblob.connection,
+      connectionString: config.get('CRAWLER_QUEUE_CONNECTION_STRING') || cd_azblob.connection,
       queueName: config.get('CRAWLER_QUEUE_PREFIX') || 'cdcrawlerdev',
       visibilityTimeout: 8 * 60 * 60, // 8 hours
       visibilityTimeout_remainLocal: fetchedCacheTtlSeconds,


### PR DESCRIPTION
# What

Makes the crawler queue configurable as a separate connection string from the Azure storage account.

By setting the env var connection string `CRAWLER_QUEUE_AZURE_CONNECTION_STRING` we can host the queues separately from the crawler.


# Why

Currently anyone who has access to CD's Azure account can access the queues of anyone else who is hosting a crawler and submitting results to CD's azure storage account.

This could lead to security issues if sensitive data leaked into the crawler queues.
Anything could be added to the queue by external entities with with access to the CD storage account.