### PR TITLE
Deploys to dev on master merge

### DIFF
--- a/.github/workflows/build-and-deploy-dev.yml
+++ b/.github/workflows/build-and-deploy-dev.yml
@@ -3,9 +3,8 @@ name: Build and Deploy -- DEV
 
 on:
   workflow_dispatch:
-  # TODO: once tested run on master push
-  # push:
-  #   branches: [master]
+  push:
+    branches: [master]
 
 jobs:
   upload-package-lock-json:


### PR DESCRIPTION
# What

Master merge will deploy dev instance of crawler in the CD Azure account. `cdcrawler-dev`

# Why

So that all 3 of the CD services are deployed by GitHub actions

Crawler was previously being deployed by Azure devops pipeline [here](https://dev.azure.com/clearlydefined/ClearlyDefined/_build?definitionId=6)

That is no longer automatically run has not been for a long time. Last build was 25/07/2024

# Testing

[Created action on prev PR](https://github.com/clearlydefined/crawler/pull/599) I've ran the action manually and it deployed to dev. And ran integration test https://github.com/clearlydefined/operations/actions/runs/11071072353/job/30762083150
With only 1 coord for speed.

