### PR TITLE
Persist manifest information for sourcearchive components

### DIFF
--- a/config/cdConfig.js
+++ b/config/cdConfig.js
@@ -99,6 +99,7 @@ module.exports = {
       format: '--json-pp'
     },
     source: {},
+    sourcearchive: {},
     top: { githubToken }
   },
   store: {

--- a/providers/index.js
+++ b/providers/index.js
@@ -48,6 +48,7 @@ module.exports = {
     scancode: require('./process/scancode'),
     fossology: require('./process/fossology'),
     source: require('./process/source').processor,
+    sourcearchive: require('./process/sourcearchiveExtract'),
     top: require('./process/top')
   },
   store: {

--- a/providers/process/sourceExtract.js
+++ b/providers/process/sourceExtract.js
@@ -15,7 +15,7 @@ class SourceExtract extends AbstractClearlyDefinedProcessor {
 
   canHandle(request) {
     const spec = this.toSpec(request)
-    return request.type === 'clearlydefined' && spec && ['git', 'sourcearchive'].includes(spec.type)
+    return request.type === 'clearlydefined' && spec && ['git'].includes(spec.type)
   }
 
   async handle(request) {

--- a/providers/process/sourcearchiveExtract.js
+++ b/providers/process/sourcearchiveExtract.js
@@ -1,0 +1,26 @@
+// (c) Copyright 2024, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const AbstractClearlyDefinedProcessor = require('./abstractClearlyDefinedProcessor')
+const { merge } = require('lodash')
+
+class SourceArchiveExtract extends AbstractClearlyDefinedProcessor {
+
+  get toolVersion() {
+    return '1.2.0'
+  }
+
+  canHandle(request) {
+    const spec = this.toSpec(request)
+    return request.type === 'clearlydefined' && spec?.type === 'sourcearchive'
+  }
+
+  async handle(request) {
+    await super.handle(request)
+    const { summary, poms, releaseDate } = request.document
+    const manifest = { summary, poms }
+    request.document = merge(this.clone(request.document), { releaseDate, manifest })
+  }
+}
+
+module.exports = options => new SourceArchiveExtract(options)

--- a/providers/process/sourcearchiveExtract.js
+++ b/providers/process/sourcearchiveExtract.js
@@ -5,7 +5,6 @@ const AbstractClearlyDefinedProcessor = require('./abstractClearlyDefinedProcess
 const { merge } = require('lodash')
 
 class SourceArchiveExtract extends AbstractClearlyDefinedProcessor {
-
   get toolVersion() {
     return '1.2.0'
   }

--- a/providers/process/sourcearchiveExtract.js
+++ b/providers/process/sourcearchiveExtract.js
@@ -19,7 +19,7 @@ class SourceArchiveExtract extends AbstractClearlyDefinedProcessor {
     await super.handle(request)
     const { summary, poms, releaseDate } = request.document
     const manifest = { summary, poms }
-    request.document = merge(this.clone(request.document), { releaseDate, manifest })
+    request.document = merge(this.clone(request.document), { manifest, releaseDate })
   }
 }
 

--- a/test/unit/providers/process/sourceArchiveExtractTests.js
+++ b/test/unit/providers/process/sourceArchiveExtractTests.js
@@ -1,0 +1,31 @@
+const { expect } = require('chai')
+const sourceArchiveExtract = require('../../../../providers/process/sourcearchiveExtract')
+const Request = require('../../../../ghcrawler').request
+
+const pomsArray = [{ pom1: 'pom1' }, { pom2: 'pom2' }]
+const summaryObj = { version: '8.1.0' }
+
+describe('SourceArchiveExtract Tests', () => {
+  it('checks the summary and poms section in clearlydefined result', async () => {
+    const { processor, request } = await setup()
+    await processor.handle(request)
+    expect(request.document.manifest.summary).to.be.deep.equal(summaryObj)
+    expect(request.document.manifest.poms).to.be.deep.equal(pomsArray)
+  })
+})
+
+async function setup() {
+  const processor = sourceArchiveExtract({ logger: {} })
+  const request = createRequest()
+  const dir = processor.createTempDir(request)
+  request.document.location = dir.name
+  request.document.summary = summaryObj
+  request.document.poms = pomsArray
+  return { processor, request }
+}
+
+function createRequest() {
+  const request = new Request('source', 'cd:/sourcearchive/mavencentral/org.osgi/osgi.annotation/8.1.0')
+  request.document = { _metadata: { links: {} }, registryData: { manifest: {} } }
+  return request
+}

--- a/test/unit/providers/process/sourceArchiveExtractTests.js
+++ b/test/unit/providers/process/sourceArchiveExtractTests.js
@@ -1,13 +1,26 @@
+// (c) Copyright 2024, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
 const { expect } = require('chai')
-const sourceArchiveExtract = require('../../../../providers/process/sourcearchiveExtract')
+const SourceArchiveExtract = require('../../../../providers/process/sourcearchiveExtract')
 const Request = require('../../../../ghcrawler').request
 
 const pomsArray = [{ pom1: 'pom1' }, { pom2: 'pom2' }]
 const summaryObj = { version: '8.1.0' }
 
 describe('SourceArchiveExtract Tests', () => {
+  let processor, request
+  beforeEach(async () => {
+    const result = await setup()
+    processor = result.processor
+    request = result.request
+  })
+
+  it('should verify version of source archive extract', () => {
+    expect(processor._schemaVersion).to.equal('1.4.0')
+  })
+
   it('checks the summary and poms section in clearlydefined result', async () => {
-    const { processor, request } = await setup()
     await processor.handle(request)
     expect(request.document.manifest.summary).to.be.deep.equal(summaryObj)
     expect(request.document.manifest.poms).to.be.deep.equal(pomsArray)
@@ -15,7 +28,7 @@ describe('SourceArchiveExtract Tests', () => {
 })
 
 async function setup() {
-  const processor = sourceArchiveExtract({ logger: {} })
+  const processor = SourceArchiveExtract({ logger: {} })
   const request = createRequest()
   const dir = processor.createTempDir(request)
   request.document.location = dir.name

--- a/test/unit/providers/process/sourceExtractTests.js
+++ b/test/unit/providers/process/sourceExtractTests.js
@@ -1,0 +1,12 @@
+// (c) Copyright 2024, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const { expect } = require('chai')
+const SourceExtract = require('../../../../providers/process/sourceExtract')
+
+describe('SourceExtract', () => {
+  it('verify version of source extract', () => {
+    const handler = SourceExtract({})
+    expect(handler._schemaVersion).to.equal('1.3.0')
+  })
+})

--- a/test/unit/providers/process/sourceExtractTests.js
+++ b/test/unit/providers/process/sourceExtractTests.js
@@ -5,7 +5,7 @@ const { expect } = require('chai')
 const SourceExtract = require('../../../../providers/process/sourceExtract')
 
 describe('SourceExtract', () => {
-  it('verify version of source extract', () => {
+  it('verifies version of the source extract', () => {
     const handler = SourceExtract({})
     expect(handler._schemaVersion).to.equal('1.3.0')
   })


### PR DESCRIPTION
Persist manifest information for sourcearchive components
This is the crawler implementation.  The service side implementation is [here](https://github.com/clearlydefined/service/pull/1234)

Task: https://github.com/clearlydefined/crawler/issues/585