### PR TITLE
Update Tool Version for mavenExtract and nugetExtract

### DIFF
--- a/providers/process/mavenExtract.js
+++ b/providers/process/mavenExtract.js
@@ -13,7 +13,7 @@ class MavenExtract extends AbstractClearlyDefinedProcessor {
   }
 
   get toolVersion() {
-    return '1.3.0'
+    return '1.3.1'
   }
 
   canHandle(request) {

--- a/providers/process/nugetExtract.js
+++ b/providers/process/nugetExtract.js
@@ -16,7 +16,7 @@ class NuGetExtract extends AbstractClearlyDefinedProcessor {
   }
 
   get toolVersion() {
-    return '1.2.2'
+    return '1.2.3'
   }
 
   canHandle(request) {

--- a/test/unit/providers/process/mavenExtractTests.js
+++ b/test/unit/providers/process/mavenExtractTests.js
@@ -7,6 +7,11 @@ const SourceSpec = require('../../../../lib/sourceSpec')
 const EntitySpec = require('../../../../lib/entitySpec')
 
 describe('mavenExtract source discovery', () => {
+  it('verifies the version of the nuget extract', () => {
+    const extractor = extract({}, () => {})
+    expect(extractor._schemaVersion).to.equal('1.5.1')
+  })
+
   it('handles no tags in GitHub and falls back to made up sourcearchive', async () => {
     const spec = createSpec('test')
     const extractor = extract({}, () => null)

--- a/test/unit/providers/process/nugetExtractTests.js
+++ b/test/unit/providers/process/nugetExtractTests.js
@@ -95,6 +95,12 @@ function createRequest() {
 }
 
 describe('nugetExtract source discovery', () => {
+  it('verifies the version of the nuget extract', () => {
+    const finder = sinon.stub().callsFake(sourceDiscovery())
+    const extractor = extract({}, finder)
+    expect(extractor._schemaVersion).to.equal('1.4.3')
+  })
+
   it('handles no tags in GitHub', async () => {
     const finder = sinon.stub().callsFake(() => null)
     const extractor = extract({}, finder)


### PR DESCRIPTION
### Tasks Completed:

- [x] **Class Identification**: Identified the extract classes that depend on the `extractLicenseFromLicenseUrl` method, which utilizes the `_licenseUrlOverrides` list.
- [x] **Tool Version Updates**: Updated tool versions within the relevant extract classes for both Maven and NuGet.
- [x] **Test Case Addition**: Added a test case to validate and verify the updated versions, ensuring the re-harvesting is possible for coordinates of nuget and maven packages.
- [x] **Manual Re-harvesting**: Manually re-harvested Maven and NuGet components on a local system. This process confirmed that the ClearlyDefined tool processes these components as expected after updating the tool version, while other tools for these components are appropriately excluded.

This PR is related to https://github.com/clearlydefined/crawler/issues/630
Find the relevant comment and discussion here https://github.com/clearlydefined/service/pull/1246#issuecomment-2533227880