### PR TITLE
Move typescript related packages to dev dependencies

### DIFF
--- a/ghcrawler/providers/storage/azureBlobFactory.js
+++ b/ghcrawler/providers/storage/azureBlobFactory.js
@@ -7,12 +7,19 @@ const AzureStorageDocStore = require('./storageDocStore')
 const { DefaultAzureCredential, ClientSecretCredential } = require('@azure/identity')
 
 /**
+ * @typedef {Object} Logger
+ * @property {(message: string) => void} info
+ */
+
+/**
  * @param {object} options
  * @param {string} options.account
  * @param {string} options.connection
  * @param {string} options.container
- * @param {object} options.logger
- * @param {object} options.spnAuth
+ * @param {Logger} options.logger
+ * @param {string} options.spnAuth
+ * @param {string} options.blobKey
+ * @param {boolean} options.preserveCase
  */
 module.exports = options => {
   options.logger.info('creating azure storage store')

--- a/ghcrawler/providers/storage/storageDocStore.js
+++ b/ghcrawler/providers/storage/storageDocStore.js
@@ -7,10 +7,17 @@ const memoryCache = require('memory-cache')
 const { Readable } = require('stream')
 const URL = require('url')
 
+/**
+ * @typedef {{[propertyName: string]: string}} BlobMetadata
+ */
+
 class AzureStorageDocStore {
   /**
    * @param {ContainerClient} containerClient
    * @param {object} options
+   * @param {string} options.blobKey
+   * @param {boolean} options.preserveCase
+   * @param {string} options.container
    */
   constructor(containerClient, options) {
     this.containerClient = containerClient
@@ -19,15 +26,19 @@ class AzureStorageDocStore {
   }
 
   async connect() {
-    await this._createContainer(this.containerClient)
+    await this._createContainer()
   }
 
-  async _createContainer(containerClient) {
-    await containerClient.createIfNotExists()
+  async _createContainer() {
+    await this.containerClient.createIfNotExists()
   }
 
+  /**
+   * @param {{ _metadata: any; }} document
+   */
   async upsert(document) {
     const blobName = this._getBlobNameFromDocument(document)
+    /** @type BlobMetadata */
     const blobMetadata = {
       version: document._metadata.version,
       etag: document._metadata.etag,
@@ -48,6 +59,10 @@ class AzureStorageDocStore {
     await blockBlobClient.uploadStream(dataStream, 8 << 20, 5, options)
   }
 
+  /**
+   * @param {string} type
+   * @param {string} key
+   */
   async get(type, key) {
     const blobName = this._getBlobNameFromKey(type, key)
     const blockBlobClient = this.containerClient.getBlockBlobClient(blobName)
@@ -56,6 +71,10 @@ class AzureStorageDocStore {
     return JSON.parse(downloaded)
   }
 
+  /**
+   * @param {string} type
+   * @param {string} key
+   */
   async etag(type, key) {
     const blobName = this._getBlobNameFromKey(type, key)
     const blockBlobClient = this.containerClient.getBlockBlobClient(blobName)
@@ -64,26 +83,36 @@ class AzureStorageDocStore {
   }
 
   // This API can only be used for the 'deadletter' store because we cannot look up documents by type performantly
+  /**
+   * @param {string} type
+   * @returns {Promise<BlobMetadata[]>}
+   */
   async list(type) {
     this._ensureDeadletter(type)
     let entries = []
     for await (const blob of this.containerClient.listBlobsFlat({ includeMetadata: true })) {
       const blobMetadata = blob.metadata
-      entries.push({
-        version: blobMetadata.version,
-        etag: blobMetadata.etag,
-        type: blobMetadata.type,
-        url: blobMetadata.url,
-        urn: blobMetadata.urn,
-        fetchedAt: blobMetadata.fetchedat,
-        processedAt: blobMetadata.processedat,
-        extra: blobMetadata.extra ? JSON.parse(blobMetadata.extra) : undefined
-      })
+      if (blobMetadata) {
+        entries.push({
+          version: blobMetadata.version,
+          etag: blobMetadata.etag,
+          type: blobMetadata.type,
+          url: blobMetadata.url,
+          urn: blobMetadata.urn,
+          fetchedAt: blobMetadata.fetchedat,
+          processedAt: blobMetadata.processedat,
+          extra: blobMetadata.extra ? JSON.parse(blobMetadata.extra) : undefined
+        })
+      }
     }
     return entries
   }
 
   // This API can only be used for the 'deadletter' store because we cannot look up documents by type performantly
+  /**
+   * @param {string} type
+   * @param {string} key
+   */
   async delete(type, key) {
     this._ensureDeadletter(type)
     const blobName = this._getBlobNameFromKey(type, key)
@@ -92,9 +121,14 @@ class AzureStorageDocStore {
   }
 
   // This API can only be used for the 'deadletter' store because we cannot look up documents by type performantly
+  /**
+   * @param {string} type
+   * @param {boolean} [force]
+   * @returns {Promise<number>}
+   */
   async count(type, force = false) {
     this._ensureDeadletter(type)
-    const key = `${this.name}:count:${type || ''}`
+    const key = `${this.options.container}:count:${type || ''}`
     if (!force) {
       const cachedCount = memoryCache.get(key)
       if (cachedCount) {
@@ -102,8 +136,9 @@ class AzureStorageDocStore {
       }
     }
     let entryCount = 0
-    const properties = await this.containerClient.getProperties()
-    properties.blobCount
+    // TODO check if this is the right way to get the count
+    // const properties = await this.containerClient.getProperties()
+    // properties.blobCount
     // eslint-disable-next-line no-unused-vars
     for await (const _ of this.containerClient.listBlobsFlat()) {
       entryCount++
@@ -116,12 +151,18 @@ class AzureStorageDocStore {
     return
   }
 
+  /**
+   * @param {string} type
+   */
   _ensureDeadletter(type) {
     if (type !== 'deadletter') {
       throw new Error('This API is only supported for deadletter.')
     }
   }
 
+  /**
+   * @param {{ _metadata: any; }} document
+   */
   _getBlobNameFromDocument(document) {
     const type = document._metadata.type
     if (this.options.blobKey === 'url') {
@@ -130,14 +171,24 @@ class AzureStorageDocStore {
     return this._getBlobNameFromUrn(type, document._metadata.links.self.href.toLowerCase())
   }
 
+  /**
+   * @param {string} type
+   * @param {string} url
+   * @returns {string}
+   */
   _getBlobNameFromUrl(type, url) {
     if (url.startsWith('urn:')) {
       return url
     }
     const parsed = URL.parse(url, true)
-    return `${type}${this.options.preserveCase ? parsed.path : parsed.path.toLowerCase()}.json`
+    return `${type}${this.options.preserveCase ? parsed.path : parsed.path?.toLowerCase()}.json`
   }
 
+  /**
+   * @param {string} type
+   * @param {string} urn
+   * @returns {string}
+   */
   _getBlobPathFromUrn(type, urn) {
     if (!urn) {
       return ''
@@ -150,6 +201,10 @@ class AzureStorageDocStore {
     return this.options.preserveCase ? replaced : replaced.toLowerCase()
   }
 
+  /**
+   * @param {string} type
+   * @param {string} urn
+   */
   _getBlobNameFromUrn(type, urn) {
     if (!urn.startsWith('urn:')) {
       return urn
@@ -157,8 +212,16 @@ class AzureStorageDocStore {
     return `${this._getBlobPathFromUrn(type, urn)}.json`
   }
 
+  /**
+   * @param {NodeJS.ReadableStream | undefined} readableStream
+   */
   async _streamToString(readableStream) {
+    if (!readableStream) {
+      // no stream, no data
+      return ''
+    }
     return new Promise((resolve, reject) => {
+      /** @type {string[]} */
       const chunks = []
       readableStream.on('data', data => {
         chunks.push(data.toString())

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@azure/storage-queue": "^12.25.0",
         "@clearlydefined/spdx": "github:clearlydefined/spdx#v0.1.9",
         "@microsoft/refreshing-config": "^0.1.3",
-        "@types/node": "^22.10.1",
         "applicationinsights": "^1.5.0",
         "ar-async": "^0.1.4",
         "axios": "^1.7.4",
@@ -55,13 +54,14 @@
         "spdx-correct": "^3.2.0",
         "throat": "^5.0.0",
         "tmp": "0.1.0",
-        "typescript": "^5.7.2",
         "unbzip2-stream": "^1.3.3",
         "winston": "^2.3.0",
         "winston-azure-application-insights": "^1.5.0",
         "xml2js": "^0.5.0"
       },
       "devDependencies": {
+        "@types/memory-cache": "^0.2.6",
+        "@types/node": "^22.10.1",
         "chai": "^4.2.0",
         "chai-as-promised": "^7.1.1",
         "chai-spies": "^1.0.0",
@@ -73,7 +73,8 @@
         "prettier": "3.2.4",
         "proxyquire": "^2.1.3",
         "request": "^2.88.2",
-        "sinon": "^5.0.0"
+        "sinon": "^5.0.0",
+        "typescript": "^5.7.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1190,10 +1191,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/memory-cache": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@types/memory-cache/-/memory-cache-0.2.6.tgz",
+      "integrity": "sha512-G+9tuwWqss2hvX+T/RNY9CY8qSvuCx8uwnl+tXQWwXtBelXUGcn4j6zknDR+2EfdrgBsMZik0jCKNlDEHIBONQ==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "22.10.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
       "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
+      "dev": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -8282,6 +8290,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
       "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8302,7 +8311,8 @@
     "node_modules/undici-types": {
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
     "mocha": "nyc mocha \"test/unit/**/*.js\"",
     "local": "node --inspect-brk=0.0.0.0:9229 ./index.js",
     "integration": "mocha \"test/integration/**/*.js\" --timeout 20000",
-    "lint": "npm run prettier:check && npm run eslint",
+    "lint": "npm run eslint && npm run tsc && npm run prettier:check",
     "lint:fix": "npm run prettier:write && npm run eslint:fix",
     "eslint": "eslint .",
     "eslint:fix": "eslint . --fix",
+    "tsc": "tsc",
     "prettier:check": "prettier . --check",
     "prettier:write": "prettier . --write",
     "postinstall": "patch-package"
@@ -39,7 +40,6 @@
     "@azure/storage-queue": "^12.25.0",
     "@clearlydefined/spdx": "github:clearlydefined/spdx#v0.1.9",
     "@microsoft/refreshing-config": "^0.1.3",
-    "@types/node": "^22.10.1",
     "applicationinsights": "^1.5.0",
     "ar-async": "^0.1.4",
     "axios": "^1.7.4",
@@ -79,13 +79,14 @@
     "spdx-correct": "^3.2.0",
     "throat": "^5.0.0",
     "tmp": "0.1.0",
-    "typescript": "^5.7.2",
     "unbzip2-stream": "^1.3.3",
     "winston": "^2.3.0",
     "winston-azure-application-insights": "^1.5.0",
     "xml2js": "^0.5.0"
   },
   "devDependencies": {
+    "@types/memory-cache": "^0.2.6",
+    "@types/node": "^22.10.1",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-spies": "^1.0.0",
@@ -97,6 +98,7 @@
     "prettier": "3.2.4",
     "proxyquire": "^2.1.3",
     "request": "^2.88.2",
-    "sinon": "^5.0.0"
+    "sinon": "^5.0.0",
+    "typescript": "^5.7.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "allowJs": true, // Allow JavaScript files to be compiled.
+    "checkJs": true, // Enable type checking on JavaScript files.
+    "noEmit": true, // Do not generate any files.
+    "strict": true, // Enable all strict type checking options.
+    "types": ["node"] // Include node type definitions.
+  },
+  "include": [
+    "ghcrawler/providers/storage/azureBlobFactory.js" // Include specific files.
+  ],
+  "exclude": [
+    "node_modules", // Exclude 'node_modules' to avoid unnecessary type-checking.
+    "docs",
+    "data",
+    "dev-scripts",
+    "patches"
+  ]
+}


### PR DESCRIPTION
- Type checking related libraries are moved to dev dependencies.
- Include type checking in lint script in package.json
- Fix errors detected by type checking