### PR TITLE
Make licensee's max degree of parallism configurable

### DIFF
--- a/config/cdConfig.js
+++ b/config/cdConfig.js
@@ -22,7 +22,7 @@ const fetchedCacheTtlSeconds = config.get('CRAWLER_FETCHED_CACHE_TTL_SECONDS') |
 
 function getPositiveNum(configName, defaultValue) {
   const num = Number(config.get(configName))
-  return num > 0 ? num : defaultValue;
+  return num > 0 ? num : defaultValue
 }
 
 module.exports = {
@@ -73,7 +73,7 @@ module.exports = {
     gem: { githubToken },
     go: { githubToken },
     licensee: {
-      processes: getPositiveNum(CRAWLER_LICENSEE_PARALLELISM,10)
+      processes: getPositiveNum(CRAWLER_LICENSEE_PARALLELISM, 10)
     },
     maven: { githubToken },
     npm: { githubToken },

--- a/config/cdConfig.js
+++ b/config/cdConfig.js
@@ -73,7 +73,7 @@ module.exports = {
     gem: { githubToken },
     go: { githubToken },
     licensee: {
-      processes: getPositiveNum(CRAWLER_LICENSEE_PARALLELISM, 10)
+      processes: getPositiveNum('CRAWLER_LICENSEE_PARALLELISM', 10)
     },
     maven: { githubToken },
     npm: { githubToken },

--- a/config/cdConfig.js
+++ b/config/cdConfig.js
@@ -20,6 +20,11 @@ const crawlerStoreProvider = config.get('CRAWLER_STORE_PROVIDER') || 'cd(file)'
 const maxRequeueAttemptCount = config.get('CRAWLER_MAX_REQUEUE_ATTEMPTS') || 5
 const fetchedCacheTtlSeconds = config.get('CRAWLER_FETCHED_CACHE_TTL_SECONDS') || 60 * 60 * 8 //8 hours
 
+function getLicenseeParallelism() {
+  const num = Number(config.get('CRAWLER_LICENSEE_PARALLELISM') || process.env.CRAWLER_LICENSEE_PARALLELISM)
+  return num > 0 ? num : 10;
+}
+
 module.exports = {
   provider: 'memory', // change this to redis if/when we want distributed config
   searchPath: [module],
@@ -67,7 +72,9 @@ module.exports = {
     },
     gem: { githubToken },
     go: { githubToken },
-    licensee: {},
+    licensee: {
+      processes: getLicenseeParallelism()
+    },
     maven: { githubToken },
     npm: { githubToken },
     nuget: { githubToken },

--- a/config/cdConfig.js
+++ b/config/cdConfig.js
@@ -20,9 +20,9 @@ const crawlerStoreProvider = config.get('CRAWLER_STORE_PROVIDER') || 'cd(file)'
 const maxRequeueAttemptCount = config.get('CRAWLER_MAX_REQUEUE_ATTEMPTS') || 5
 const fetchedCacheTtlSeconds = config.get('CRAWLER_FETCHED_CACHE_TTL_SECONDS') || 60 * 60 * 8 //8 hours
 
-function getLicenseeParallelism() {
-  const num = Number(config.get('CRAWLER_LICENSEE_PARALLELISM') || process.env.CRAWLER_LICENSEE_PARALLELISM)
-  return num > 0 ? num : 10;
+function getPositiveNum(configName, defaultValue) {
+  const num = Number(config.get(configName))
+  return num > 0 ? num : defaultValue;
 }
 
 module.exports = {

--- a/config/cdConfig.js
+++ b/config/cdConfig.js
@@ -73,7 +73,7 @@ module.exports = {
     gem: { githubToken },
     go: { githubToken },
     licensee: {
-      processes: getLicenseeParallelism()
+      processes: getPositiveNum(CRAWLER_LICENSEE_PARALLELISM,10)
     },
     maven: { githubToken },
     npm: { githubToken },

--- a/providers/process/licensee.js
+++ b/providers/process/licensee.js
@@ -50,9 +50,10 @@ class LicenseeProcessor extends AbstractProcessor {
     const root = request.document.location
     const subfolders = await this.getFolders(root, ['/.git'])
     const paths = ['', ...trimAllParents(subfolders, root)]
+    const { processes } = this.options
     try {
       const results = (
-        await Promise.all(paths.map(throat(10, path => this._runOnFolder(path, root, parameters))))
+        await Promise.all(paths.map(throat(processes, path => this._runOnFolder(path, root, parameters))))
       ).filter(x => x)
       const licenses = uniqBy(flatten(results.map(result => result.licenses)), 'spdx_id')
       const matched_files = flatten(results.map(result => result.matched_files))

--- a/test/unit/providers/process/licenseeTests.js
+++ b/test/unit/providers/process/licenseeTests.js
@@ -69,7 +69,7 @@ describe('Licensee process', () => {
 })
 
 function setup(fixture, error, versionError) {
-  const options = { logger: { log: sinon.stub() } }
+  const options = { logger: { log: sinon.stub() }, processes: 10 }
   const testRequest = new request('npm', 'cd:/npm/npmjs/-/test/1.1')
   testRequest.document = { _metadata: { links: {} }, location: path.resolve(`test/fixtures/licensee/${fixture}`) }
   testRequest.crawler = { storeDeadletter: sinon.stub() }


### PR DESCRIPTION
via `CRAWLER_LICENSEE_PARALLELISM`.
The default of 10 stays as is.

Fixes https://github.com/clearlydefined/crawler/issues/640