### PR TITLE
Fix biome warnings

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
   "files": {
     "includes": [
       "**",

--- a/ghcrawler/lib/traversalPolicy.js
+++ b/ghcrawler/lib/traversalPolicy.js
@@ -225,12 +225,7 @@ class TraversalPolicy {
       return TraversalPolicy._hasExpired(request.document?._metadata?.processedAt, this.freshness * 24, 'hours')
     }
     if (this.freshness === 'version' || this.freshness === 'matchOrVersion') {
-      return (
-        !request.document ||
-        !request.document._metadata ||
-        !request.document._metadata.version ||
-        request.document._metadata.version < version
-      )
+      return !request.document?._metadata?.version || request.document._metadata.version < version
     }
     throw new Error('Invalid freshness in traversal policy')
   }

--- a/ghcrawler/providers/queuing/storageQueue.js
+++ b/ghcrawler/providers/queuing/storageQueue.js
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation and others. Made available under the MIT license.
 // SPDX-License-Identifier: MIT
 
-// eslint-disable-next-line no-unused-vars
-const { QueueServiceClient } = require('@azure/storage-queue')
+/** @typedef {import('@azure/storage-queue').QueueServiceClient} QueueServiceClient */
 const qlimit = require('qlimit')
 const { cloneDeep } = require('lodash')
 
@@ -87,7 +86,7 @@ class StorageQueue {
   }
 
   async done(request) {
-    if (!request || !request._message) {
+    if (!request?._message) {
       return
     }
     await this.queueClient.deleteMessage(request._message.messageId, request._message.popReceipt)
@@ -99,7 +98,7 @@ class StorageQueue {
   }
 
   async abandon(request) {
-    if (!request || !request._message) {
+    if (!request?._message) {
       return
     }
     await this.updateVisibilityTimeout(request)

--- a/ghcrawler/providers/storage/storageDocStore.js
+++ b/ghcrawler/providers/storage/storageDocStore.js
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// eslint-disable-next-line no-unused-vars
-const { ContainerClient } = require('@azure/storage-blob')
+/** @typedef {import('@azure/storage-blob').ContainerClient} ContainerClient */
 const memoryCache = require('memory-cache')
 const URL = require('node:url')
 

--- a/providers/fetch/cratesioFetch.js
+++ b/providers/fetch/cratesioFetch.js
@@ -17,7 +17,7 @@ class CratesioFetch extends AbstractFetch {
   async handle(request) {
     const spec = this.toSpec(request)
     const registryData = await this._getRegistryData(spec)
-    if (!registryData || !registryData.version) {
+    if (!registryData?.version) {
       return this.markSkip(request)
     }
     const version = registryData.version

--- a/providers/fetch/dispatcher.js
+++ b/providers/fetch/dispatcher.js
@@ -95,7 +95,6 @@ class FetchDispatcher extends AbstractFetch {
     this.logger.debug(`---Start Fetch: ${cacheKey} at ${new Date().toISOString()}`)
     await handler.handle(request)
     const fetchResult = request.fetchResult
-    // biome-ignore lint/performance/noDelete: setting to undefined changes semantics for deep-equal checks
     delete request.fetchResult
     if (fetchResult) {
       this._addToCache(cacheKey, fetchResult)

--- a/providers/fetch/mavenBasedFetch.js
+++ b/providers/fetch/mavenBasedFetch.js
@@ -150,7 +150,7 @@ class MavenBasedFetch extends AbstractFetch {
   }
 
   _buildParentSpec(pom, spec) {
-    if (!pom || !pom.project || !pom.project.parent) {
+    if (!pom?.project?.parent) {
       return null
     }
     const parent = pom.project.parent[0]

--- a/providers/fetch/npmjsFetch.js
+++ b/providers/fetch/npmjsFetch.js
@@ -75,7 +75,7 @@ class NpmFetch extends AbstractFetch {
       }
       return null
     }
-    if (!registryData || !registryData.versions) {
+    if (!registryData?.versions) {
       return null
     }
     const version = spec.revision || this.getLatestVersion(Object.keys(registryData.versions))
@@ -102,7 +102,7 @@ class NpmFetch extends AbstractFetch {
   }
 
   _getCasedSpec(spec, registryData) {
-    if (!registryData || !registryData.name) {
+    if (!registryData?.name) {
       return false
     }
     const parts = registryData.name.split('/')

--- a/providers/fetch/packagistFetch.js
+++ b/providers/fetch/packagistFetch.js
@@ -22,7 +22,7 @@ class PackagistFetch extends AbstractFetch {
   async handle(request) {
     const spec = this.toSpec(request)
     const registryData = await this._getRegistryData(spec)
-    if (!registryData || !registryData.manifest) {
+    if (!registryData?.manifest) {
       return this.markSkip(request)
     }
     super.handle(request)

--- a/providers/fetch/podFetch.js
+++ b/providers/fetch/podFetch.js
@@ -26,7 +26,7 @@ class PodFetch extends AbstractFetch {
 
     // Ensure we have a spec revision, we can't get the registry data without one
     const version = await this._getVersion(spec)
-    if (!version || !version.name) {
+    if (!version?.name) {
       return request.markSkip('Missing  ')
     }
     spec.revision = version.name

--- a/providers/fetch/pypiFetch.js
+++ b/providers/fetch/pypiFetch.js
@@ -60,7 +60,7 @@ class PyPiFetch extends AbstractFetch {
   }
 
   _getRevision(registryData) {
-    if (!registryData || !registryData.releases) {
+    if (!registryData?.releases) {
       return null
     }
     return findLastKey(registryData.releases)

--- a/providers/process/abstractProcessor.js
+++ b/providers/process/abstractProcessor.js
@@ -95,7 +95,7 @@ class AbstractProcessor extends BaseHandler {
    * @param {string} location - Root filesystem path that hosts the files to be attached
    */
   async attachFiles(document, files, location = '') {
-    if (!files || !files.length) {
+    if (!files?.length) {
       return
     }
     if (!document._attachments) {


### PR DESCRIPTION
`biome check .` was reporting 14 warnings and 1 info. This clears all of them.

**What changed:**

- Bumped the biome.json schema from 2.4.8 to 2.4.11 to match the installed CLI version
- Replaced manual null-check chains (`!x || !x.prop`) with optional chaining (`!x?.prop`) in 10 places across fetch and process providers. These are all object/array checks where the semantics are identical.
- Converted two runtime imports (`QueueServiceClient`, `ContainerClient`) that only existed for JSDoc `@param` types into `@typedef` imports, removing the unused variables and their stale `eslint-disable-next-line` comments
- Removed a `biome-ignore lint/performance/noDelete` comment in `dispatcher.js` that no longer suppressed anything